### PR TITLE
release: history-preserving modernization sync (#0000)

### DIFF
--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -40,7 +40,10 @@ jobs:
   ux-regression-gate:
     name: UX Regression Gate
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    # The active golden workload emits its structured receipt after the
+    # scenarios finish; keep the gate bounded while allowing that receipt to
+    # complete on a cold hosted runner.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -304,6 +304,9 @@ impl LspServer {
                         let text_owned = text.to_string();
                         let uri_owned = uri.to_string();
                         let generation = Arc::clone(&generation);
+                        let active_document_readiness = self.runtime_tuning().runtime_mode
+                            == perl_lsp_rs_core::runtime::tuning::RuntimeMode::E2e;
+                        let outbound = self.outbound.clone();
                         let task_counter = Arc::clone(&self.pending_index_task_count);
                         task_counter.fetch_add(1, Ordering::SeqCst);
 
@@ -319,6 +322,11 @@ impl LspServer {
                             }
                             match workspace_index.index_file_with_generation(url, text_owned, 0) {
                                 Ok(()) => {
+                                    if active_document_readiness {
+                                        workspace_progress::send_active_document_ready_notification(
+                                            &outbound, &uri_owned, 0,
+                                        );
+                                    }
                                     if matches!(
                                         coordinator_clone.state(),
                                         IndexState::Building { phase: IndexPhase::Idle, .. }

--- a/crates/perl-lsp-rs/src/runtime/text_sync/tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync/tests.rs
@@ -1322,6 +1322,47 @@ fn test_did_close_preserves_workspace_index_for_existing_file()
     Ok(())
 }
 
+#[cfg(feature = "workspace")]
+#[test]
+fn e2e_did_open_publishes_active_document_ready_after_index_commit()
+-> Result<(), Box<dyn std::error::Error>> {
+    let buf = StdArc::new(parking_lot::Mutex::new(Vec::<u8>::new()));
+    let writer = SharedVecWriter { inner: StdArc::clone(&buf) };
+    let server = LspServer::with_io_feature_profile_and_tuning(
+        Box::new(std::io::Cursor::new(Vec::<u8>::new())),
+        Box::new(writer),
+        FeatureProfile::current(),
+        perl_lsp_rs_core::runtime::tuning::RuntimeTuning::e2e_defaults(),
+    );
+    let uri = "file:///test_active_document_ready.pl";
+
+    server.did_open(json!({
+        "textDocument": {
+            "uri": uri,
+            "languageId": "perl",
+            "version": 1,
+            "text": "package Active::Ready;\nsub ready { 1 }\n1;\n"
+        }
+    }))?;
+    drop(server);
+    std::thread::sleep(Duration::from_millis(50));
+
+    let text = String::from_utf8(buf.lock().clone()).unwrap_or_default();
+    assert!(
+        text.contains(r#""method":"perl-lsp/active-document-ready""#),
+        "e2e didOpen must publish active-document readiness; got: {text:?}"
+    );
+    assert!(
+        text.contains(&format!(r#""uri":"{}""#, uri)),
+        "active-document readiness must identify the opened URI; got: {text:?}"
+    );
+    assert!(
+        text.contains(r#""generation":0"#),
+        "active-document readiness must identify the opened generation; got: {text:?}"
+    );
+    Ok(())
+}
+
 /// didClose must clear diagnostics using the client-provided URI string.
 ///
 /// This preserves exact URI identity for clients that key diagnostics by

--- a/crates/perl-lsp-rs/src/runtime/workspace_progress.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace_progress.rs
@@ -18,6 +18,20 @@ pub(super) fn send_index_ready_notification(outbound: &OutboundSender, ready: bo
 }
 
 #[cfg(feature = "workspace")]
+pub(super) fn send_active_document_ready_notification(
+    outbound: &OutboundSender,
+    uri: &str,
+    generation: u64,
+) {
+    if let Err(e) = outbound.send_notification(
+        "perl-lsp/active-document-ready",
+        json!({ "uri": uri, "generation": generation }),
+    ) {
+        tracing::warn!(error = %e, "Failed to send active-document-ready notification");
+    }
+}
+
+#[cfg(feature = "workspace")]
 pub(super) fn send_progress_create(outbound: &OutboundSender, request_id: ServerRequestId) {
     if let Err(e) = outbound.send_request(
         request_id,

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -2008,6 +2008,35 @@
       ]
     },
     {
+      "id": "golden_editor_workload",
+      "scenario_file": "ux_scenario_67_golden_editor_workload.rs",
+      "subsystem_owner": "editor_trust",
+      "ci_tier": "pr",
+      "component": "infra",
+      "instrumentation": {
+        "run_receipt": true,
+        "first_useful_result": true,
+        "protocol_goldens": false
+      },
+      "user_journey": "run the after-active-document-ready daily-driver workload across representative real-workspace fixtures and record bounded provider behavior",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
+      ],
+      "expected_outcomes": [
+        "the active document reaches the readiness event before the workload begins",
+        "the workload records first-useful provider timings without claiming whole-workspace readiness or exactness",
+        "fallback, request-superseded, and other bounded outcomes remain visible in the receipt",
+        "the server stays responsive and does not crash"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
       "id": "strict_warnings_guided_edit",
       "scenario_file": "ux_scenario_68_strict_warnings_guided_edit.rs",
       "subsystem_owner": "editor_trust",

--- a/crates/perl-lsp-ux-tests/fixtures/golden_editor_workload.json
+++ b/crates/perl-lsp-ux-tests/fixtures/golden_editor_workload.json
@@ -1,0 +1,100 @@
+{
+  "kind": "golden_editor_workload",
+  "schema_version": 2,
+  "manifest_version": "2026-07-13",
+  "claim_boundary": "After active-document-ready transport and provider-receipt baseline only. This run starts journeys after the active document's E2E indexing pass, does not claim whole-workspace readiness, does not measure pre-index behavior or time to first useful answer, does not promote provider support tiers, and does not score exactness before a request class has a checked-in proof packet.",
+  "projects": [
+    {
+      "name": "mojolicious",
+      "fixture": "mojolicious",
+      "active_file": "lib/Mojolicious.pm",
+      "completion_needle": "$self->",
+      "definition_needle": "startup",
+      "reference_needle": "$plugins",
+      "safe_rename_needle": "$plugins"
+    },
+    {
+      "name": "dancer2",
+      "fixture": "dancer2",
+      "active_file": "lib/Dancer2/Core/Runner.pm",
+      "completion_needle": "$self->",
+      "definition_needle": "psgi_app",
+      "reference_needle": "$runner",
+      "safe_rename_needle": "$runner"
+    },
+    {
+      "name": "catalyst",
+      "fixture": "catalyst",
+      "active_file": "lib/Catalyst.pm",
+      "completion_needle": "$self->",
+      "definition_needle": "_setup",
+      "reference_needle": "$self",
+      "safe_rename_needle": "%args"
+    },
+    {
+      "name": "plain_modern_oo",
+      "fixture": "inline_plain_modern_oo",
+      "active_file": "lib/Plain/App.pm",
+      "completion_needle": "$self->",
+      "definition_needle": "run",
+      "reference_needle": "$value",
+      "safe_rename_needle": "$value"
+    }
+  ],
+  "journeys": [
+    { "id": "completion_after_ready", "provider": "completion", "request_shape": "active_document_ready", "expected_result_class": "bounded_or_exact" },
+    { "id": "hover_after_ready", "provider": "hover", "request_shape": "local_symbol", "expected_result_class": "bounded_or_exact" },
+    { "id": "definition_local_or_imported", "provider": "definition", "request_shape": "local_or_imported_symbol", "expected_result_class": "bounded_or_exact" },
+    { "id": "references_lexical", "provider": "references", "request_shape": "initialized_lexical", "expected_result_class": "bounded_or_exact" },
+    { "id": "rename_safe_lexical", "provider": "rename", "request_shape": "safe_initialized_lexical", "expected_result_class": "exact_or_refused" },
+    { "id": "diagnostics_present_import", "provider": "diagnostics", "request_shape": "present_import", "expected_result_class": "non_error" },
+    { "id": "workspace_symbols_after_ready", "provider": "workspace_symbols", "request_shape": "workspace_query", "expected_result_class": "bounded_or_exact" },
+    { "id": "edit_burst_completion", "provider": "completion", "request_shape": "twenty_edit_burst", "expected_result_class": "bounded_or_exact" },
+    { "id": "edit_burst_hover", "provider": "hover", "request_shape": "twenty_edit_burst", "expected_result_class": "bounded_or_exact" },
+    { "id": "close_reopen_pending", "provider": "lifecycle", "request_shape": "close_reopen_while_pending", "expected_result_class": "non_error" }
+  ],
+  "zero_budget_metrics": [
+    "exactness_state",
+    "unwaived_error_count",
+    "unsafe_external_edit_count",
+    "protocol_crash_count",
+    "unexplained_empty_count"
+  ],
+  "error_waivers": [
+    {
+      "project": "mojolicious",
+      "journey": "edit_burst_completion",
+      "expected_error_class": "request_superseded",
+      "issue": 4050,
+      "expires_after": "2026-08-01"
+    },
+    {
+      "project": "dancer2",
+      "journey": "edit_burst_completion",
+      "expected_error_class": "request_superseded",
+      "issue": 4050,
+      "expires_after": "2026-08-01"
+    },
+    {
+      "project": "catalyst",
+      "journey": "edit_burst_completion",
+      "expected_error_class": "request_superseded",
+      "issue": 4050,
+      "expires_after": "2026-08-01"
+    },
+    {
+      "project": "plain_modern_oo",
+      "journey": "edit_burst_completion",
+      "expected_error_class": "request_superseded",
+      "issue": 4050,
+      "expires_after": "2026-08-01"
+    },
+    {
+      "project": "plain_modern_oo",
+      "journey": "rename_safe_lexical",
+      "expected_error_class": "timeout",
+      "issue": 4050,
+      "expires_after": "2026-08-01"
+    }
+  ]
+}

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -128,6 +128,14 @@ fn is_index_ready_event(event: &LspEvent) -> bool {
     method == "perl-lsp/index-ready" && params.get("ready").and_then(Value::as_bool) == Some(true)
 }
 
+fn is_active_document_ready_event(event: &LspEvent, uri: &str) -> bool {
+    let LspEvent::Other { method, params } = event else {
+        return false;
+    };
+    method == "perl-lsp/active-document-ready"
+        && params.get("uri").and_then(Value::as_str) == Some(uri)
+}
+
 /// Configuration for a UX scenario.
 ///
 /// Centralises all the knobs that affect the test environment without
@@ -551,6 +559,26 @@ impl UxHarness {
     /// Count ready-index notifications already observed by the harness.
     pub fn index_ready_event_count(&self) -> usize {
         self.client.peek_events().iter().filter(|event| is_index_ready_event(event)).count()
+    }
+
+    /// Wait until the server confirms that a specific active document has
+    /// completed its E2E background indexing pass.
+    pub fn wait_for_active_document_ready(&self, uri: &str, timeout: Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if self
+                .client
+                .peek_events()
+                .iter()
+                .any(|event| is_active_document_ready_event(event, uri))
+            {
+                return true;
+            }
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
     }
 
     /// Wait until a ready-index notification arrives after `already_seen` events.
@@ -1322,8 +1350,9 @@ pub fn find_perlcritic() -> Option<String> {
 #[cfg(test)]
 mod normalize_tests {
     use super::{
-        document_symbol_names, find_binary_near_exe, is_index_ready_event, is_truthy_env_value,
-        normalize_lsp_payload, normalize_uri_for_expectations,
+        document_symbol_names, find_binary_near_exe, is_active_document_ready_event,
+        is_index_ready_event, is_truthy_env_value, normalize_lsp_payload,
+        normalize_uri_for_expectations,
     };
     use crate::LspEvent;
     use serde_json::{Value, json};
@@ -1369,6 +1398,24 @@ mod normalize_tests {
             message_type: 3,
             message: "perl-lsp/index-ready".to_string(),
         }));
+        Ok(())
+    }
+
+    #[test]
+    fn active_document_ready_event_requires_matching_uri() -> anyhow::Result<()> {
+        let event = LspEvent::Other {
+            method: "perl-lsp/active-document-ready".to_string(),
+            params: json!({ "uri": "file:///active.pl", "generation": 0 }),
+        };
+        assert!(is_active_document_ready_event(&event, "file:///active.pl"));
+        assert!(!is_active_document_ready_event(&event, "file:///other.pl"));
+        assert!(!is_active_document_ready_event(
+            &LspEvent::Other {
+                method: "perl-lsp/index-ready".to_string(),
+                params: json!({ "uri": "file:///active.pl" }),
+            },
+            "file:///active.pl",
+        ));
         Ok(())
     }
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_67_golden_editor_workload.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_67_golden_editor_workload.rs
@@ -1,0 +1,982 @@
+//! Scenario 67 - checked-in golden daily-driver workload baseline.
+//!
+//! The manifest is deliberately broader than the current exact-support proof.
+//! This runner records the observed result class and provider receipt for each
+//! journey without promoting a support tier or turning a fallback into an
+//! exactness claim.
+
+use anyhow::{Context, Result, anyhow, ensure};
+use perl_lsp_ux_tests::{
+    ProjectFixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, fixture_scenario_config, load_catalyst_fixture_files,
+    load_dancer2_fixture_files, load_mojolicious_fixture_files, missing_binary_skip,
+    open_all_fixture_files, run_ux_scenario,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use url::Url;
+
+const SCENARIO_FILE: &str = "ux_scenario_67_golden_editor_workload.rs";
+const MANIFEST: &str = include_str!("../fixtures/golden_editor_workload.json");
+const PLAIN_ACTIVE_FILE: &str = "lib/Plain/App.pm";
+const PLAIN_SOURCE: &str = r#"package Plain::App;
+use strict;
+use warnings;
+
+sub new {
+    my ($class) = @_;
+    return bless {}, $class;
+}
+
+sub run {
+    my ($self) = @_;
+    my $value = $self->value;
+    return $value;
+}
+
+sub value {
+    return 1;
+}
+
+1;
+"#;
+
+#[test]
+fn golden_manifest_has_exact_after_ready_shape() -> Result<()> {
+    let manifest: WorkloadManifest = serde_json::from_str(MANIFEST)?;
+    validate_manifest(&manifest)
+}
+
+#[test]
+fn waiver_expiry_rejects_malformed_and_expired_dates() -> Result<()> {
+    ensure!(validate_waiver_expiry("9999-12-31").is_ok());
+    ensure!(validate_waiver_expiry("2026-02-30").is_err());
+    ensure!(validate_waiver_expiry("2020-01-01").is_err());
+    Ok(())
+}
+
+#[test]
+fn cursor_positions_use_utf16_code_units() -> Result<()> {
+    let cursor = position_from_offset("x😀", "x😀".len())?;
+    ensure!(cursor.line == 0 && cursor.character == 3, "unexpected UTF-16 cursor: {cursor:?}");
+    Ok(())
+}
+
+#[test]
+fn resource_operations_are_checked_for_external_targets() -> Result<()> {
+    let safe = json!({
+        "documentChanges": [{ "oldUri": "file:///workspace/lib/App.pm", "newUri": "file:///workspace/lib/App.pm" }]
+    });
+    let unsafe_edit = json!({
+        "documentChanges": [{ "kind": "create", "uri": "file:///workspace/other.pm" }]
+    });
+    ensure!(!rename_edit_targets_other_file(&safe, "file:///workspace/lib/App.pm"));
+    ensure!(rename_edit_targets_other_file(&unsafe_edit, "file:///workspace/lib/App.pm"));
+    let suffix_collision = json!({
+        "changes": { "file:///workspace/other/lib/App.pm": [] }
+    });
+    ensure!(rename_edit_targets_other_file(&suffix_collision, "file:///workspace/lib/App.pm"));
+    Ok(())
+}
+
+#[test]
+fn unexplained_empty_results_count_against_zero_budget() -> Result<()> {
+    let rollup =
+        build_rollup(&[test_workload_row("empty", "empty_result_requires_class_proof")], &[], 0)?;
+    ensure!(rollup.unexplained_empty_count == 1);
+    Ok(())
+}
+
+#[test]
+fn protocol_crashes_are_preserved_in_the_rollup() -> Result<()> {
+    let rollup = build_rollup(&[], &[], 2)?;
+    ensure!(rollup.protocol_crash_count == 2);
+    Ok(())
+}
+
+#[cfg(test)]
+fn test_workload_row(actual_result_class: &str, fallback_or_blocker: &str) -> WorkloadRow {
+    WorkloadRow {
+        project: "test".to_owned(),
+        journey: "test".to_owned(),
+        provider: "test".to_owned(),
+        source_snapshot: "checked_in_fixture",
+        file: "lib/App.pm".to_owned(),
+        cursor: CursorReceipt { line: 0, character: 0 },
+        request_shape: "test".to_owned(),
+        expected_result_class: "test".to_owned(),
+        actual_result_class: actual_result_class.to_owned(),
+        error_class: "not_applicable".to_owned(),
+        actual_locations: Value::Null,
+        actual_edits: Value::Null,
+        missing: Vec::new(),
+        extra: Vec::new(),
+        comparison: "not_scored_until_class_promotion",
+        answering_tier: "not_observed".to_owned(),
+        fact_producer: "not_observed".to_owned(),
+        proof_class: "baseline_only".to_owned(),
+        confidence: "not_observed".to_owned(),
+        freshness: "not_observed".to_owned(),
+        fallback_or_blocker: fallback_or_blocker.to_owned(),
+        readiness_state: "active_document_ready".to_owned(),
+        latency_ms: 1.0,
+        unsafe_edit: false,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkloadManifest {
+    kind: String,
+    schema_version: u32,
+    manifest_version: String,
+    claim_boundary: String,
+    projects: Vec<ProjectSpec>,
+    journeys: Vec<JourneySpec>,
+    zero_budget_metrics: Vec<String>,
+    error_waivers: Vec<ErrorWaiver>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectSpec {
+    name: String,
+    fixture: String,
+    active_file: String,
+    completion_needle: String,
+    definition_needle: String,
+    reference_needle: String,
+    safe_rename_needle: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct JourneySpec {
+    id: String,
+    provider: String,
+    request_shape: String,
+    expected_result_class: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorWaiver {
+    project: String,
+    journey: String,
+    expected_error_class: String,
+    issue: u64,
+    expires_after: String,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkloadReceipt {
+    kind: &'static str,
+    schema_version: u32,
+    measured_at_unix_ms: u128,
+    manifest_version: String,
+    claim_boundary: String,
+    run_identity: RunIdentity,
+    projects: Vec<ProjectReceipt>,
+    rows: Vec<WorkloadRow>,
+    rollup: Rollup,
+}
+
+#[derive(Debug, Serialize)]
+struct RunIdentity {
+    commit: Option<String>,
+    run_id: Option<String>,
+    ci: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ProjectReceipt {
+    project: String,
+    fixture: String,
+    source_snapshot: &'static str,
+    file_count: usize,
+    active_file: String,
+    active_document_ready: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkloadRow {
+    project: String,
+    journey: String,
+    provider: String,
+    source_snapshot: &'static str,
+    file: String,
+    cursor: CursorReceipt,
+    request_shape: String,
+    expected_result_class: String,
+    actual_result_class: String,
+    error_class: String,
+    actual_locations: Value,
+    actual_edits: Value,
+    missing: Vec<String>,
+    extra: Vec<String>,
+    comparison: &'static str,
+    answering_tier: String,
+    fact_producer: String,
+    proof_class: String,
+    confidence: String,
+    freshness: String,
+    fallback_or_blocker: String,
+    readiness_state: String,
+    latency_ms: f64,
+    unsafe_edit: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct CursorReceipt {
+    line: u32,
+    character: u32,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct Rollup {
+    exactness_state: &'static str,
+    false_exact_count: &'static str,
+    stale_exact_count: &'static str,
+    unsafe_external_edit_count: usize,
+    bounded_fallback_count: usize,
+    unexplained_empty_count: usize,
+    unwaived_error_count: usize,
+    protocol_crash_count: usize,
+    measured_debt_count: usize,
+    p50_latency_ms: Option<f64>,
+    p95_latency_ms: Option<f64>,
+}
+
+#[test]
+fn scenario_67_golden_editor_workload_receipt() {
+    run_ux_scenario(
+        "golden_daily_driver_workload",
+        SCENARIO_FILE,
+        "scenario_67_golden_editor_workload_receipt",
+        UxCiTier::Pr,
+        Some(UxComponent::Infra),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let manifest: WorkloadManifest =
+                serde_json::from_str(MANIFEST).context("golden workload manifest must parse")?;
+            validate_manifest(&manifest)?;
+
+            let mut rows = Vec::new();
+            let mut project_receipts = Vec::new();
+            let mut protocol_crash_count = 0;
+            for project in &manifest.projects {
+                let files = project_files(project)?;
+                let harness = create_harness(project, &files)?;
+                let source = if project.fixture == "inline_plain_modern_oo" {
+                    PLAIN_SOURCE.to_owned()
+                } else {
+                    fixture_content(&files, &project.active_file)?.to_owned()
+                };
+                if files.is_empty() {
+                    harness.open_file(&project.active_file, &source)?;
+                } else {
+                    open_all_fixture_files(&harness, &files)?;
+                }
+                let active_uri = harness.workspace.uri(&project.active_file);
+                let active_document_ready =
+                    harness.wait_for_active_document_ready(&active_uri, Duration::from_secs(30));
+                ensure!(
+                    active_document_ready,
+                    "after-ready workload project {} did not reach active-document readiness",
+                    project.name
+                );
+                project_receipts.push(ProjectReceipt {
+                    project: project.name.clone(),
+                    fixture: project.fixture.clone(),
+                    source_snapshot: "checked_in_fixture",
+                    file_count: files.len()
+                        + usize::from(project.fixture == "inline_plain_modern_oo"),
+                    active_file: project.active_file.clone(),
+                    active_document_ready,
+                });
+
+                run_project_workload(
+                    recorder,
+                    &manifest.journeys,
+                    project,
+                    &source,
+                    &harness,
+                    active_document_ready,
+                    &mut rows,
+                )?;
+                protocol_crash_count += count_protocol_crash_events(&harness);
+            }
+
+            let rollup = build_rollup(&rows, &manifest.error_waivers, protocol_crash_count)?;
+            let receipt = WorkloadReceipt {
+                kind: "golden_editor_workload",
+                schema_version: 2,
+                measured_at_unix_ms: SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+                manifest_version: manifest.manifest_version,
+                claim_boundary: manifest.claim_boundary,
+                run_identity: RunIdentity {
+                    commit: std::env::var("GITHUB_SHA").ok(),
+                    run_id: std::env::var("GITHUB_RUN_ID").ok(),
+                    ci: std::env::var("CI").is_ok(),
+                },
+                projects: project_receipts,
+                rows,
+                rollup,
+            };
+            write_workload_receipt(&receipt)?;
+
+            recorder.check("golden workload produced rows", !receipt.rows.is_empty())?;
+            recorder.check(
+                "exactness remains explicitly unscored",
+                receipt.rollup.exactness_state == "not_scored"
+                    && receipt.rollup.false_exact_count == "not_measured"
+                    && receipt.rollup.stale_exact_count == "not_measured",
+            )?;
+            recorder.check(
+                "unsafe external edit count remains zero",
+                receipt.rollup.unsafe_external_edit_count == 0,
+            )?;
+            recorder.check(
+                "unwaived request errors remain zero",
+                receipt.rollup.unwaived_error_count == 0,
+            )?;
+            recorder.check(
+                "unexplained empty count remains zero",
+                receipt.rollup.unexplained_empty_count == 0,
+            )?;
+            recorder.check(
+                "protocol crash count remains zero",
+                receipt.rollup.protocol_crash_count == 0,
+            )?;
+            Ok(())
+        },
+    );
+}
+
+fn validate_manifest(manifest: &WorkloadManifest) -> Result<()> {
+    ensure!(manifest.kind == "golden_editor_workload", "unexpected manifest kind");
+    ensure!(manifest.schema_version == 2, "unsupported manifest schema");
+    let expected_projects =
+        BTreeSet::from(["catalyst", "dancer2", "mojolicious", "plain_modern_oo"]);
+    let actual_projects =
+        manifest.projects.iter().map(|project| project.name.as_str()).collect::<BTreeSet<_>>();
+    ensure!(
+        actual_projects == expected_projects,
+        "workload must cover the exact four projects once"
+    );
+    ensure!(
+        manifest.projects.len() == expected_projects.len(),
+        "workload contains duplicate projects"
+    );
+    let expected_journeys = BTreeSet::from([
+        "close_reopen_pending",
+        "completion_after_ready",
+        "definition_local_or_imported",
+        "diagnostics_present_import",
+        "edit_burst_completion",
+        "edit_burst_hover",
+        "hover_after_ready",
+        "references_lexical",
+        "rename_safe_lexical",
+        "workspace_symbols_after_ready",
+    ]);
+    let actual_journeys =
+        manifest.journeys.iter().map(|journey| journey.id.as_str()).collect::<BTreeSet<_>>();
+    ensure!(
+        actual_journeys == expected_journeys,
+        "workload must cover the exact ten journeys once"
+    );
+    ensure!(
+        manifest.journeys.len() == expected_journeys.len(),
+        "workload contains duplicate journeys"
+    );
+    for metric in [
+        "exactness_state",
+        "unwaived_error_count",
+        "unsafe_external_edit_count",
+        "protocol_crash_count",
+        "unexplained_empty_count",
+    ] {
+        ensure!(
+            manifest.zero_budget_metrics.iter().any(|candidate| candidate == metric),
+            "manifest is missing zero-budget metric {metric}"
+        );
+    }
+    for waiver in &manifest.error_waivers {
+        ensure!(waiver.issue > 0, "error waiver must name a tracking issue");
+        validate_waiver_expiry(&waiver.expires_after)?;
+    }
+    Ok(())
+}
+
+fn validate_waiver_expiry(expires_after: &str) -> Result<()> {
+    let mut parts = expires_after.split('-');
+    let year = parts.next().context("waiver expiry is missing a year")?.parse::<i64>()?;
+    let month = parts.next().context("waiver expiry is missing a month")?.parse::<u32>()?;
+    let day = parts.next().context("waiver expiry is missing a day")?.parse::<u32>()?;
+    ensure!(parts.next().is_none(), "waiver expiry must use YYYY-MM-DD: {expires_after}");
+    ensure!(expires_after.len() == 10, "waiver expiry must use YYYY-MM-DD: {expires_after}");
+    ensure!((1..=12).contains(&month), "waiver expiry month is invalid: {expires_after}");
+    let days_in_month = match month {
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        4 | 6 | 9 | 11 => 30,
+        _ => 31,
+    };
+    ensure!((1..=days_in_month).contains(&day), "waiver expiry day is invalid: {expires_after}");
+
+    let expiry_days = days_from_civil(year, month, day);
+    let today_days =
+        i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() / 86_400)?;
+    ensure!(
+        expiry_days >= today_days,
+        "error waiver expired on {expires_after}; refresh or remove the waiver"
+    );
+    Ok(())
+}
+
+fn is_leap_year(year: i64) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+}
+
+/// Return days since 1970-01-01 for a proleptic Gregorian calendar date.
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let year = year - if month <= 2 { 1 } else { 0 };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let month_prime = i64::from(month) + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * month_prime + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+fn project_files(project: &ProjectSpec) -> Result<Vec<ProjectFixtureFile>> {
+    match project.fixture.as_str() {
+        "mojolicious" => load_mojolicious_fixture_files(),
+        "dancer2" => load_dancer2_fixture_files(),
+        "catalyst" => load_catalyst_fixture_files(),
+        "inline_plain_modern_oo" => Ok(Vec::new()),
+        other => Err(anyhow!("unknown workload fixture {other}")),
+    }
+}
+
+fn create_harness(project: &ProjectSpec, files: &[ProjectFixtureFile]) -> Result<UxHarness> {
+    if project.fixture == "inline_plain_modern_oo" {
+        return UxHarness::new(
+            ScenarioConfig { timeout: Duration::from_secs(30), ..Default::default() }
+                .env("PERL_LSP_WORKSPACE", "1")
+                .env("PERL_LSP_E2E", "1")
+                .with_file(PLAIN_ACTIVE_FILE, PLAIN_SOURCE),
+        );
+    }
+    UxHarness::new(fixture_scenario_config(files).env("PERL_LSP_E2E", "1"))
+}
+
+fn run_project_workload(
+    recorder: &mut perl_lsp_ux_tests::UxRunRecorder,
+    journeys: &[JourneySpec],
+    project: &ProjectSpec,
+    source: &str,
+    harness: &UxHarness,
+    active_document_ready: bool,
+    rows: &mut Vec<WorkloadRow>,
+) -> Result<()> {
+    let completion_cursor = position_after(source, &project.completion_needle)?;
+    let definition_cursor = position_at(source, &project.definition_needle)?;
+    let reference_cursor = position_at(source, &project.reference_needle)?;
+    let rename_cursor = position_at(source, &project.safe_rename_needle)?;
+
+    for journey in journeys {
+        let operation = operation_name(project, journey);
+        recorder.mark_request_start(&operation);
+        let request_started = Instant::now();
+        let (cursor, response, actual_edits) = match journey.id.as_str() {
+            "completion_after_ready" => (
+                completion_cursor,
+                capture(harness.completion(
+                    &project.active_file,
+                    completion_cursor.line,
+                    completion_cursor.character,
+                )),
+                Value::Null,
+            ),
+            "hover_after_ready" => (
+                reference_cursor,
+                capture(
+                    harness
+                        .hover(
+                            &project.active_file,
+                            reference_cursor.line,
+                            reference_cursor.character,
+                        )
+                        .map(|value| value.unwrap_or(Value::Null)),
+                ),
+                Value::Null,
+            ),
+            "definition_local_or_imported" => (
+                definition_cursor,
+                capture(harness.definition(
+                    &project.active_file,
+                    definition_cursor.line,
+                    definition_cursor.character,
+                )),
+                Value::Null,
+            ),
+            "references_lexical" => (
+                reference_cursor,
+                capture(harness.references(
+                    &project.active_file,
+                    reference_cursor.line,
+                    reference_cursor.character,
+                    true,
+                )),
+                Value::Null,
+            ),
+            "rename_safe_lexical" => {
+                let result = capture(request_rename(harness, &project.active_file, rename_cursor));
+                let edits = result.clone();
+                (rename_cursor, result, edits)
+            }
+            "diagnostics_present_import" => {
+                let diagnostics =
+                    harness.wait_for_diagnostics(&project.active_file, Duration::from_secs(5));
+                (CursorReceipt { line: 0, character: 0 }, json!(diagnostics), Value::Null)
+            }
+            "workspace_symbols_after_ready" => (
+                CursorReceipt { line: 0, character: 0 },
+                capture(harness.workspace_symbols("new")),
+                Value::Null,
+            ),
+            "edit_burst_completion" => (
+                completion_cursor,
+                run_edit_burst_completion(
+                    harness,
+                    &project.active_file,
+                    source,
+                    completion_cursor,
+                )?,
+                Value::Null,
+            ),
+            "edit_burst_hover" => (
+                reference_cursor,
+                run_edit_burst_hover(harness, &project.active_file, source, reference_cursor)?,
+                Value::Null,
+            ),
+            "close_reopen_pending" => {
+                let uri = harness.workspace.uri(&project.active_file);
+                harness
+                    .client
+                    .notify("textDocument/didClose", json!({"textDocument": {"uri": uri}}))?;
+                harness.open_file(&project.active_file, source)?;
+                (CursorReceipt { line: 0, character: 0 }, json!({"reopened": true}), Value::Null)
+            }
+            other => return Err(anyhow!("unhandled golden workload journey {other}")),
+        };
+        let request_latency_ms = request_started.elapsed().as_secs_f64() * 1000.0;
+
+        let row = response_row(
+            project,
+            journey,
+            cursor,
+            response,
+            actual_edits,
+            if active_document_ready { "active_document_ready" } else { "active_document_pending" },
+            request_latency_ms,
+            harness,
+        )?;
+        let row = if journey.provider == "lifecycle" {
+            apply_lifecycle_receipt(row)
+        } else {
+            let receipt_id = format!(
+                "golden_{project_name}_{journey_id}",
+                project_name = project.name,
+                journey_id = journey.id,
+            );
+            let receipt_provider = receipt_provider_name(&journey.provider);
+            let provider_receipt = explain_provider(
+                harness,
+                receipt_provider,
+                &receipt_id,
+                journey.id.as_str(),
+                cursor,
+            )?;
+            apply_provider_receipt(row, Ok(provider_receipt))
+        };
+        if row.actual_result_class != "empty" && row.actual_result_class != "error" {
+            recorder.mark_first_useful_result(&operation);
+        }
+        rows.push(row);
+    }
+    Ok(())
+}
+
+fn receipt_provider_name(provider: &str) -> &str {
+    match provider {
+        "definition" => "goto_definition",
+        other => other,
+    }
+}
+
+fn run_edit_burst_completion(
+    harness: &UxHarness,
+    file: &str,
+    source: &str,
+    cursor: CursorReceipt,
+) -> Result<Value> {
+    for edit in 0..20 {
+        harness.change_file_full(file, &format!("{source}\n# golden editor burst {edit}"))?;
+    }
+    // The initial active-document-ready gate is already established. The
+    // burst intentionally measures provider behavior while edits are pending;
+    // it does not claim post-edit workspace readiness.
+    let response = capture(harness.completion(file, cursor.line, cursor.character));
+    harness.change_file_full(file, source)?;
+    Ok(response)
+}
+
+fn run_edit_burst_hover(
+    harness: &UxHarness,
+    file: &str,
+    source: &str,
+    cursor: CursorReceipt,
+) -> Result<Value> {
+    for edit in 0..20 {
+        harness.change_file_full(file, &format!("{source}\n# golden editor burst {edit}"))?;
+    }
+    let response = capture(
+        harness
+            .hover(file, cursor.line, cursor.character)
+            .map(|value| value.unwrap_or(Value::Null)),
+    );
+    harness.change_file_full(file, source)?;
+    Ok(response)
+}
+
+fn request_rename(harness: &UxHarness, file: &str, cursor: CursorReceipt) -> Result<Value> {
+    let response = harness.client.request(
+        "textDocument/rename",
+        json!({
+            "textDocument": { "uri": harness.workspace.uri(file) },
+            "position": { "line": cursor.line, "character": cursor.character },
+            "newName": "golden_renamed_value"
+        }),
+        Duration::from_secs(5),
+    )?;
+    ensure!(response.get("error").is_none(), "rename returned a protocol error: {response}");
+    Ok(response.get("result").cloned().unwrap_or(Value::Null))
+}
+
+fn response_row(
+    project: &ProjectSpec,
+    journey: &JourneySpec,
+    cursor: CursorReceipt,
+    response: Value,
+    actual_edits: Value,
+    readiness_state: &str,
+    latency_ms: f64,
+    harness: &UxHarness,
+) -> Result<WorkloadRow> {
+    let actual_result_class = classify_result(&response, journey.provider.as_str());
+    let error_class = if actual_result_class == "error" {
+        classify_error(&response)
+    } else {
+        "not_applicable".to_owned()
+    };
+    let is_empty = actual_result_class == "empty";
+    let fallback_or_blocker =
+        response.get("_golden_error").and_then(Value::as_str).map(str::to_owned).unwrap_or_else(
+            || {
+                if is_empty {
+                    "empty_result_requires_class_proof".to_owned()
+                } else {
+                    "not_observed".to_owned()
+                }
+            },
+        );
+    let actual_locations = if matches!(journey.provider.as_str(), "definition" | "references") {
+        harness.normalize_response(&response)
+    } else {
+        Value::Array(Vec::new())
+    };
+    let normalized_edits = harness.normalize_response(&actual_edits);
+    let active_uri = harness.workspace.uri(&project.active_file);
+    let unsafe_edit = journey.provider == "rename"
+        && rename_edit_targets_other_file(&normalized_edits, &active_uri);
+    Ok(WorkloadRow {
+        project: project.name.clone(),
+        journey: journey.id.clone(),
+        provider: journey.provider.clone(),
+        source_snapshot: "checked_in_fixture",
+        file: project.active_file.clone(),
+        cursor,
+        request_shape: journey.request_shape.clone(),
+        expected_result_class: journey.expected_result_class.clone(),
+        actual_result_class,
+        error_class,
+        actual_locations,
+        actual_edits: normalized_edits,
+        missing: Vec::new(),
+        extra: Vec::new(),
+        comparison: "not_scored_until_class_promotion",
+        answering_tier: "not_observed".to_owned(),
+        fact_producer: "not_observed".to_owned(),
+        proof_class: "baseline_only".to_owned(),
+        confidence: "not_observed".to_owned(),
+        freshness: "not_observed".to_owned(),
+        fallback_or_blocker,
+        readiness_state: readiness_state.to_owned(),
+        latency_ms,
+        unsafe_edit,
+    })
+}
+
+fn classify_error(response: &Value) -> String {
+    let message = response.get("_golden_error").and_then(Value::as_str).unwrap_or_default();
+    let message_lower = message.to_ascii_lowercase();
+    if message_lower.contains("request superseded") {
+        "request_superseded".to_owned()
+    } else if message_lower.contains("timeout") || message_lower.contains("timed out") {
+        "timeout".to_owned()
+    } else {
+        "request_error".to_owned()
+    }
+}
+
+fn apply_lifecycle_receipt(mut row: WorkloadRow) -> WorkloadRow {
+    row.answering_tier = "lifecycle".to_owned();
+    row.fact_producer = "transport".to_owned();
+    row.proof_class = "lifecycle".to_owned();
+    row.confidence = "not_applicable".to_owned();
+    row.freshness = "current".to_owned();
+    row.fallback_or_blocker = "lifecycle_evidence".to_owned();
+    row
+}
+
+fn apply_provider_receipt(mut row: WorkloadRow, receipt: Result<Value>) -> WorkloadRow {
+    let Ok(receipt) = receipt else {
+        return row;
+    };
+    row.answering_tier = string_field(&receipt, "answering_tier");
+    row.fact_producer = string_field(&receipt, "fact_source");
+    row.confidence = string_field(&receipt, "confidence");
+    row.freshness = string_field(&receipt, "freshness");
+    row.proof_class = string_field(&receipt, "proof_class");
+    if row.actual_result_class != "error" {
+        row.fallback_or_blocker = receipt
+            .get("fallback")
+            .or_else(|| receipt.get("fallback_state"))
+            .and_then(Value::as_str)
+            .unwrap_or(&row.fallback_or_blocker)
+            .to_owned();
+    }
+    row
+}
+
+fn explain_provider(
+    harness: &UxHarness,
+    provider: &str,
+    receipt_id: &str,
+    journey: &str,
+    cursor: CursorReceipt,
+) -> Result<Value> {
+    let response = harness.client.request(
+        "workspace/executeCommand",
+        json!({
+            "command": "perl.explainProviderDecision",
+            "arguments": [{
+                "provider": provider,
+                "receipt_id": receipt_id,
+                "scenario": "golden_daily_driver_workload",
+                "request_position": {
+                    "uri_scheme": "file",
+                    "line": cursor.line,
+                    "character": cursor.character
+                }
+            }]
+        }),
+        Duration::from_secs(20),
+    )?;
+    ensure!(response.get("error").is_none(), "provider explanation returned an error: {response}");
+    let result = response.get("result").cloned().unwrap_or(Value::Null);
+    ensure!(
+        result.get("provider").and_then(Value::as_str) == Some(provider),
+        "provider receipt for {journey} returned the wrong provider"
+    );
+    ensure!(
+        result.get("receipt_id").and_then(Value::as_str) == Some(receipt_id),
+        "provider receipt for {journey} was not bound to request {receipt_id}"
+    );
+    ensure!(
+        result.get("scenario").and_then(Value::as_str) == Some("golden_daily_driver_workload"),
+        "provider receipt for {journey} was not bound to the workload scenario"
+    );
+    Ok(result)
+}
+
+fn classify_result(response: &Value, provider: &str) -> String {
+    if response.is_null() {
+        return if provider == "rename" { "refused" } else { "empty" }.to_owned();
+    }
+    if response.get("error").is_some() || response.get("_golden_error").is_some() {
+        return "error".to_owned();
+    }
+    if response.as_array().is_some_and(Vec::is_empty) {
+        return "empty".to_owned();
+    }
+    if provider == "rename" && response.as_object().is_some_and(|object| object.is_empty()) {
+        return "refused".to_owned();
+    }
+    "partial".to_owned()
+}
+
+fn capture<T: serde::Serialize>(result: Result<T>) -> Value {
+    match result {
+        Ok(value) => json!(value),
+        Err(error) => json!({ "_golden_error": error.to_string() }),
+    }
+}
+
+fn string_field(value: &Value, field: &str) -> String {
+    value.get(field).and_then(Value::as_str).unwrap_or("not_observed").to_owned()
+}
+
+fn operation_name(project: &ProjectSpec, journey: &JourneySpec) -> String {
+    format!("golden_{}_{}", project.name, journey.id)
+}
+
+fn build_rollup(
+    rows: &[WorkloadRow],
+    error_waivers: &[ErrorWaiver],
+    protocol_crash_count: usize,
+) -> Result<Rollup> {
+    let mut rollup = Rollup {
+        exactness_state: "not_scored",
+        false_exact_count: "not_measured",
+        stale_exact_count: "not_measured",
+        protocol_crash_count,
+        ..Rollup::default()
+    };
+    let mut latencies = Vec::with_capacity(rows.len());
+    for row in rows {
+        latencies.push(row.latency_ms);
+        match row.actual_result_class.as_str() {
+            "error" => {
+                if error_waivers.iter().any(|waiver| {
+                    waiver.project == row.project
+                        && waiver.journey == row.journey
+                        && waiver.expected_error_class == row.error_class
+                }) {
+                    rollup.measured_debt_count += 1;
+                } else {
+                    rollup.unwaived_error_count += 1;
+                }
+            }
+            "empty" => {
+                rollup.unexplained_empty_count += usize::from(matches!(
+                    row.fallback_or_blocker.as_str(),
+                    "not_observed" | "empty_result_requires_class_proof"
+                ));
+                rollup.measured_debt_count += 1;
+            }
+            "partial" => rollup.bounded_fallback_count += 1,
+            "refused" => rollup.measured_debt_count += 1,
+            _ => {}
+        }
+        rollup.unsafe_external_edit_count += usize::from(row.unsafe_edit);
+    }
+    latencies.sort_by(f64::total_cmp);
+    rollup.p50_latency_ms = percentile(&latencies, 0.50);
+    rollup.p95_latency_ms = percentile(&latencies, 0.95);
+    Ok(rollup)
+}
+
+fn rename_edit_targets_other_file(edit: &Value, active_uri: &str) -> bool {
+    let mut unsafe_edit = false;
+    if let Some(changes) = edit.get("changes").and_then(Value::as_object) {
+        unsafe_edit |= changes.keys().any(|uri| !same_document_uri(uri, active_uri));
+    }
+    if let Some(changes) = edit.get("documentChanges").and_then(Value::as_array) {
+        unsafe_edit |= changes.iter().any(|change| {
+            [
+                change.pointer("/textDocument/uri"),
+                change.get("uri"),
+                change.get("oldUri"),
+                change.get("newUri"),
+            ]
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .any(|uri| !same_document_uri(uri, active_uri))
+        });
+    }
+    unsafe_edit
+}
+
+fn same_document_uri(left: &str, right: &str) -> bool {
+    match (Url::parse(left), Url::parse(right)) {
+        (Ok(left), Ok(right)) if left.scheme() == "file" && right.scheme() == "file" => {
+            left.host_str() == right.host_str() && left.path() == right.path()
+        }
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
+fn count_protocol_crash_events(harness: &UxHarness) -> usize {
+    harness
+        .peek_notifications()
+        .iter()
+        .filter(|event| {
+            let message = format!("{event:?}");
+            message.contains("panicked")
+                || message.contains("SIGABRT")
+                || message.contains("stack overflow")
+        })
+        .count()
+}
+
+fn percentile(values: &[f64], fraction: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let index = ((values.len() - 1) as f64 * fraction).round() as usize;
+    values.get(index).copied()
+}
+
+fn write_workload_receipt(receipt: &WorkloadReceipt) -> Result<PathBuf> {
+    let directory = std::env::var_os("PERL_LSP_UX_RECEIPT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("target/receipts/editor-ux"));
+    fs::create_dir_all(&directory)
+        .with_context(|| format!("creating receipt directory {}", directory.display()))?;
+    let path = directory.join("golden-editor-workload-v1.json");
+    let content = serde_json::to_string_pretty(receipt).context("serializing workload receipt")?;
+    fs::write(&path, format!("{content}\n"))
+        .with_context(|| format!("writing workload receipt {}", path.display()))?;
+    Ok(path)
+}
+
+fn position_at(source: &str, needle: &str) -> Result<CursorReceipt> {
+    let offset = source.find(needle).with_context(|| format!("missing `{needle}`"))?;
+    position_from_offset(source, offset)
+}
+
+fn position_after(source: &str, needle: &str) -> Result<CursorReceipt> {
+    let offset = source
+        .find(needle)
+        .with_context(|| format!("missing `{needle}`"))?
+        .checked_add(needle.len())
+        .context("cursor offset overflow")?;
+    position_from_offset(source, offset)
+}
+
+fn position_from_offset(source: &str, offset: usize) -> Result<CursorReceipt> {
+    let prefix = source.get(..offset).context("cursor is not a UTF-8 boundary")?;
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count();
+    let character =
+        prefix.rsplit('\n').next().map(|line| line.chars().map(char::len_utf16).sum()).unwrap_or(0);
+    Ok(CursorReceipt { line: u32::try_from(line)?, character: u32::try_from(character)? })
+}

--- a/docs/swarm/source-syncs/2026-07-15-final-modernization-f6b7b2c66.md
+++ b/docs/swarm/source-syncs/2026-07-15-final-modernization-f6b7b2c66.md
@@ -1,0 +1,61 @@
+# Source Sync Receipt: 2026-07-15 final modernization cut
+
+## Sync identity
+
+| Field | Value |
+|---|---|
+| Swarm repository | `perl-lsp-swarm` |
+| Pinned swarm cut | `sync/vscode-modernization-final-cut-f6b7b2c66` |
+| Swarm cut SHA | `f6b7b2c6626fbefbf01c9c9934cac5789186f8b2` |
+| Target repository | `perl-lsp` |
+| Target base SHA | `900c63f96507c273a562ab4623dceb1e0f39b843` |
+| Target sync merge SHA | `9fab4c6703efb5ed7691aca670263a1827741b4c` |
+| Merge parents | `900c63f96507c273a562ab4623dceb1e0f39b843`, `f6b7b2c6626fbefbf01c9c9934cac5789186f8b2` |
+| Direction | swarm → target, history-preserving complete-tree merge |
+
+## Included modernization work
+
+This cut includes the merged workspace runtime-state extraction (#4384),
+diagnostic command boundary and direct tests (#4389), and the reconciled
+modernization closeout (#4392), along with the current mainline source at the
+pinned cut. The cut preserves the individual swarm commit trail and does not
+publish, tag, or release either repository.
+
+## Exclusions
+
+The complete-tree difference from the pinned cut is limited to the documented
+target-owned or swarm-only exclusions:
+
+- `.claude/` restored from target `master`;
+- `scripts/agent-cleanup.ps1` removed;
+- `scripts/agent-preflight.ps1` removed;
+- `scripts/swarm-clean` removed;
+- target-owned sync ledgers retained under `docs/swarm/source-syncs/`.
+
+No per-file resolution was used for shared source files. Release-lineage
+documents remain governed by the target repository's sync protocol.
+
+## Verification
+
+The following checks passed against the target sync tree:
+
+```text
+git log -1 --format='%p'                 # exactly two parents
+git diff --name-only <swarm-cut>        # approved exclusions only
+cargo check --workspace --locked
+npm run doctor                           # Node 26.5.0 / npm 11.18.0
+npm ci
+npm run fmt:check
+npm run lint                             # Oxlint 0 errors / 0 warnings
+npm run typecheck:all
+npm run compile
+npm run test:ci                           # 797 passed, 1 documented skip
+npm run package
+npm run check:package-inventory           # 28 files, 1,474,277 bytes
+npm run check:source-map
+npm run test:workspace-capabilities      # exact-source trusted multi-root/untrusted
+```
+
+These checks establish the target-tree build, test, package, and workspace
+capability contracts. They do not authorize Marketplace/Open VSX upload,
+publishing, tagging, Docker publication, or release creation.

--- a/vscode-extension/docs/migrations/lane-closeout.md
+++ b/vscode-extension/docs/migrations/lane-closeout.md
@@ -1,9 +1,9 @@
 # VS Code client/toolchain modernization lane closeout
 
-Status: implementation hardening and the first history-preserving
-cross-repository sync are complete on `main`. The synchronized code cut is
-recorded in target PR [#10001](https://github.com/EffortlessMetrics/perl-lsp/pull/10001)
-and the final target ledger is maintained in `perl-lsp`.
+Status: implementation hardening and history-preserving cross-repository sync
+are complete on `main`. The earlier synchronized code cut is recorded in
+target PR [#10001](https://github.com/EffortlessMetrics/perl-lsp/pull/10001),
+and the final hardening cut is ready for the next target ledger entry.
 
 This closeout records the reviewable PR trail, the evidence boundary, and the
 completed handoff for the modernization lane. It does not publish, tag, or
@@ -64,7 +64,7 @@ release either repository.
 | #4302 | Typed POD preview contract                           | Merged |
 | #4333 | VS Code host-floor compatibility proof               | Merged |
 | #4335 | Workspace topology capability receipts               | Merged |
-| #4375 | Workspace capability host-mode proof                  | Merged |
+| #4375 | Workspace capability host-mode proof                 | Merged |
 | #4336 | Bundle source-map evidence archive                   | Merged |
 | #4338 | Feature activation timing attribution                | Merged |
 | #4339 | Server command composition                           | Merged |
@@ -79,6 +79,8 @@ release either repository.
 | #4365 | Refactoring command composition                      | Merged |
 | #4366 | Final VSIX inventory baseline refresh                | Merged |
 | #4368 | Support/report issue command composition             | Merged |
+| #4384 | Workspace runtime-state ownership                    | Merged |
+| #4389 | Diagnostic command boundary and focused tests        | Merged |
 
 Each slice was refreshed from current `origin/main` when necessary and kept
 to its owned production seam, direct proof, and required generated artifacts.
@@ -126,14 +128,16 @@ npm run test:ci
 ```
 
 The focused downloader run passed 113 tests; the latest full extension gate on
-the current hardening head passed 794 tests with one documented packaged-server
+the current hardening head passed 797 tests with one documented packaged-server
 skip. The focused command-composition slices add isolated delegation and
 disposal proof for the server, critic, test, onboarding, navigation,
-diagnostic, document, refactoring, and support groups. The final package
-evidence contains 28 inventoried files, 1,472,504 bytes total, and a
-1,314,887-byte bundle; the inventory and source-map checks pass. These checks prove the
-exercised behavior and packaging paths; they do not establish a performance
-budget or prove every platform-specific release condition.
+diagnostic, document, refactoring, and support groups. The runtime-state and
+diagnostic command boundaries add direct tests for injected lifecycle state,
+output, unavailable-state messaging, and request failures. The final package
+evidence contains 28 inventoried files, 1,474,277 bytes total, and a
+1,316,660-byte bundle; the inventory and source-map checks pass. These checks
+prove the exercised behavior and packaging paths; they do not establish a
+performance budget or prove every platform-specific release condition.
 
 The workspace capability proof also records exact-source Windows host receipts
 for trusted multi-root workspaces (two folders) and genuinely untrusted
@@ -158,6 +162,12 @@ with the target-owned `.claude/`, swarm-only cleanup scripts, and sync ledgers
 as the only approved tree differences. The exact ancestry and tree audit are
 recorded in `perl-lsp/docs/swarm/source-syncs/2026-07-15-workspace-capabilities-bd3eb11b2.md`.
 The final target ledger update merged as target PR #10002.
+
+The post-sync hardening slices #4384 and #4389 are merged on `main` and are
+included in the final stable cut used for the next history-preserving target
+sync. That cut retains the complete swarm commit trail; its target ledger will
+record the exact SHA, two-parent merge, approved exclusions, and target-side
+proofs.
 
 Issue #4120 was closed by merged PR #4121; that historical issue state does not
 change the current Node 26/npm 11 authority.

--- a/vscode-extension/scripts/vsix-inventory-baseline.json
+++ b/vscode-extension/scripts/vsix-inventory-baseline.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "total_files": 28,
-  "total_bytes": 1472504,
+  "total_bytes": 1472562,
   "files": {
     "README.md": 21701,
     "package.json": 53908,
@@ -12,11 +12,11 @@
     "CHANGELOG.md": 16170,
     ".oxlintrc.json": 559,
     ".oxfmtrc.json": 203,
-    "syntaxes/perl.tmLanguage.json": 11634,
-    "syntaxes/gherkin.tmLanguage.json": 1875,
     "snippets/perl.json": 12172,
     "snippets/launch.json": 1139,
-    "out/extension.js": 1314887,
+    "syntaxes/perl.tmLanguage.json": 11634,
+    "syntaxes/gherkin.tmLanguage.json": 1875,
+    "out/extension.js": 1314945,
     "media/walkthrough/welcome.svg": 756,
     "media/walkthrough/verify-perl.svg": 1189,
     "media/walkthrough/try-goto-definition.svg": 1852,

--- a/vscode-extension/scripts/vsix-inventory-baseline.json
+++ b/vscode-extension/scripts/vsix-inventory-baseline.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "total_files": 28,
-  "total_bytes": 1472562,
+  "total_bytes": 1474277,
   "files": {
     "README.md": 21701,
     "package.json": 53908,
@@ -12,11 +12,11 @@
     "CHANGELOG.md": 16170,
     ".oxlintrc.json": 559,
     ".oxfmtrc.json": 203,
-    "snippets/perl.json": 12172,
-    "snippets/launch.json": 1139,
     "syntaxes/perl.tmLanguage.json": 11634,
     "syntaxes/gherkin.tmLanguage.json": 1875,
-    "out/extension.js": 1314945,
+    "snippets/perl.json": 12172,
+    "snippets/launch.json": 1139,
+    "out/extension.js": 1316660,
     "media/walkthrough/welcome.svg": 756,
     "media/walkthrough/verify-perl.svg": 1189,
     "media/walkthrough/try-goto-definition.svg": 1852,

--- a/vscode-extension/src/diagnosticCommands.ts
+++ b/vscode-extension/src/diagnosticCommands.ts
@@ -1,0 +1,633 @@
+import * as vscode from 'vscode';
+import { workspaceTrustClientRuntimeState } from './workspaceTrustRuntimeState';
+
+export type LspExecuteCommandClient = {
+  sendRequest<T>(method: string, params: unknown): Promise<T>;
+};
+
+export interface DiagnosticCommandOptions {
+  readonly outputChannel?: vscode.OutputChannel;
+  readonly serverNotRunningMessage?: () => string;
+}
+
+type ProviderDecisionQuickPickItem = vscode.QuickPickItem & {
+  provider: string;
+};
+
+const PROVIDER_DECISION_OPTIONS: ProviderDecisionQuickPickItem[] = [
+  { label: 'Completion', provider: 'completion' },
+  { label: 'Goto definition', provider: 'goto_definition' },
+  { label: 'References', provider: 'references' },
+  { label: 'Hover', provider: 'hover' },
+  { label: 'Diagnostics', provider: 'diagnostics' },
+  { label: 'Rename', provider: 'rename' },
+  { label: 'Safe delete', provider: 'safe_delete' },
+  { label: 'Workspace symbols', provider: 'workspace_symbols' },
+  { label: 'Document symbols', provider: 'document_symbols' },
+  { label: 'Semantic tokens', provider: 'semantic_tokens' },
+  { label: 'Module resolution', provider: 'module_resolution' },
+  { label: 'DAP module paths', provider: 'dap_module_paths' },
+  { label: 'Perl subprocess', provider: 'perl_subprocess' },
+];
+
+function outputChannel(options: DiagnosticCommandOptions): vscode.OutputChannel {
+  return options.outputChannel ?? vscode.window.createOutputChannel('Perl LSP Trust');
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringField(
+  value: Record<string, unknown> | undefined,
+  field: string,
+): string | undefined {
+  const fieldValue = value?.[field];
+  return typeof fieldValue === 'string' ? fieldValue : undefined;
+}
+
+function numberField(
+  value: Record<string, unknown> | undefined,
+  field: string,
+): number | undefined {
+  const fieldValue = value?.[field];
+  return typeof fieldValue === 'number' ? fieldValue : undefined;
+}
+
+function booleanField(
+  value: Record<string, unknown> | undefined,
+  field: string,
+): boolean | undefined {
+  const fieldValue = value?.[field];
+  return typeof fieldValue === 'boolean' ? fieldValue : undefined;
+}
+
+function arrayField(value: Record<string, unknown> | undefined, field: string): unknown[] {
+  const fieldValue = value?.[field];
+  return Array.isArray(fieldValue) ? fieldValue : [];
+}
+
+function providerDecisionJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function activeRequestPosition(): Record<string, unknown> | undefined {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    return undefined;
+  }
+
+  return {
+    uri_scheme: editor.document.uri.toString().split(':', 1)[0] || 'file',
+    line: editor.selection.active.line,
+    character: editor.selection.active.character,
+  };
+}
+
+function providerDecisionArgument(provider: string): Record<string, unknown> {
+  const argument: Record<string, unknown> = { provider };
+  const requestPosition = activeRequestPosition();
+  if (requestPosition) {
+    argument.request_position = requestPosition;
+  }
+  return argument;
+}
+
+function activeSafeDeletePreviewArgument(): Record<string, unknown> | undefined {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== 'perl') {
+    return undefined;
+  }
+
+  return {
+    textDocument: { uri: editor.document.uri.toString() },
+    position: {
+      line: editor.selection.active.line,
+      character: editor.selection.active.character,
+    },
+  };
+}
+
+function isPerlModuleName(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$/.test(value);
+}
+
+function moduleNameAtCursor(editor: vscode.TextEditor): string | undefined {
+  const selectedText = editor.document.getText(editor.selection).trim();
+  if (isPerlModuleName(selectedText)) {
+    return selectedText;
+  }
+
+  const active = editor.selection.active;
+  const lineText = editor.document.lineAt(active.line).text;
+  const modulePattern = /[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)+/g;
+  for (const match of lineText.matchAll(modulePattern)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    if (active.character >= start && active.character <= end) {
+      return match[0];
+    }
+  }
+
+  const useStatement = lineText.match(
+    /\b(?:use|require)\s+([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)/,
+  );
+  return useStatement?.[1];
+}
+
+async function executeLspCommand(
+  activeClient: LspExecuteCommandClient | undefined,
+  command: string,
+  argument: Record<string, unknown> | undefined,
+  options: DiagnosticCommandOptions,
+): Promise<unknown | undefined> {
+  if (!activeClient) {
+    vscode.window.showWarningMessage(
+      options.serverNotRunningMessage?.() ??
+        'Perl Language Server is not running. Run the Health Check to diagnose the issue.',
+    );
+    return undefined;
+  }
+
+  try {
+    return await activeClient.sendRequest('workspace/executeCommand', {
+      command,
+      arguments: argument === undefined ? [] : [argument],
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(`Perl LSP command failed: ${message}`);
+    return undefined;
+  }
+}
+
+async function chooseProvider(providerOverride?: string): Promise<string | undefined> {
+  if (providerOverride) {
+    return providerOverride;
+  }
+
+  const selection = await vscode.window.showQuickPick(PROVIDER_DECISION_OPTIONS, {
+    placeHolder: 'Choose a provider decision to explain',
+  });
+  return selection?.provider;
+}
+
+async function showProviderDecisionResult(
+  title: string,
+  result: unknown,
+  options: DiagnosticCommandOptions,
+): Promise<void> {
+  const resultObject = asObject(result);
+  const message = stringField(resultObject, 'user_message') ?? `${title} completed.`;
+  const channel = outputChannel(options);
+  channel.appendLine('');
+  channel.appendLine(`[${title}]`);
+  channel.appendLine(providerDecisionJson(result));
+
+  const action =
+    stringField(resultObject, 'decision') === 'blocked'
+      ? await vscode.window.showWarningMessage(message, 'Show Output')
+      : await vscode.window.showInformationMessage(message, 'Show Output');
+
+  if (action === 'Show Output') {
+    channel.show();
+  }
+}
+
+function appendSupportTierLines(
+  lines: string[],
+  supportTiers: Record<string, unknown> | undefined,
+): void {
+  if (!supportTiers) {
+    lines.push('- support tiers: unavailable');
+    return;
+  }
+
+  for (const [surface, tier] of Object.entries(supportTiers).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (typeof tier === 'string') {
+      lines.push(`- ${surface}: ${tier}`);
+    }
+  }
+}
+
+function formatWorkspaceTrustReport(result: unknown): string {
+  const report = asObject(result);
+  const workspace = asObject(report?.workspace);
+  const moduleResolution = asObject(report?.module_resolution);
+  const globalConfig = asObject(moduleResolution?.global_workspace_config);
+  const index = asObject(report?.index);
+  const providers = asObject(report?.providers);
+  const supportTiers = asObject(providers?.support_tiers);
+  const dynamicBoundaries = asObject(report?.dynamic_boundaries);
+  const setupHints = asObject(report?.setup_hints);
+  const clientRuntime = asObject(report?.client_runtime_state);
+  const setupHintItems = arrayField(setupHints, 'hints');
+  const perlBinary = asObject(setupHints?.perl_binary);
+  const perldoc = asObject(setupHints?.perldoc);
+  const dap = asObject(setupHints?.dap);
+  const clientPerldoc = asObject(clientRuntime?.perldoc);
+  const clientDap = asObject(clientRuntime?.dap);
+  const launchConfiguration = asObject(clientDap?.launch_configuration);
+
+  const rootPath = stringField(workspace, 'root_path') ?? '(none)';
+  const folderCount = numberField(workspace, 'workspace_folder_count') ?? 0;
+  const openDocumentCount = numberField(workspace, 'open_document_count') ?? 0;
+  const includePaths = arrayField(globalConfig, 'include_paths');
+  const effectiveIncludePaths = arrayField(globalConfig, 'effective_include_paths');
+  const usePerl5lib = booleanField(globalConfig, 'use_perl5lib');
+  const perl5libCount = numberField(globalConfig, 'perl5lib_entry_count') ?? 0;
+  const indexState = stringField(index, 'state') ?? 'unknown';
+  const indexAvailability = stringField(index, 'availability') ?? 'unknown';
+  const indexedFileCount = numberField(index, 'indexed_file_count') ?? 0;
+  const indexedSymbolCount = numberField(index, 'indexed_symbol_count') ?? 0;
+  const traceCount = numberField(providers, 'decision_trace_count') ?? 0;
+
+  const lines = [
+    'Perl LSP Trust Report',
+    '',
+    `Schema: ${stringField(report, 'schema_version') ?? 'unknown'}`,
+    `Root: ${rootPath}`,
+    `Workspace folders: ${folderCount}`,
+    `Open documents: ${openDocumentCount}`,
+    '',
+    'Module resolution / @INC',
+    `- configured include paths: ${includePaths.length}`,
+    `- effective include paths: ${effectiveIncludePaths.length}`,
+    `- system @INC: ${stringField(globalConfig, 'system_inc_status') ?? 'unknown'}`,
+    `- PERL5LIB enabled: ${usePerl5lib === undefined ? 'unknown' : String(usePerl5lib)}`,
+    `- PERL5LIB entries: ${perl5libCount}`,
+    `- perl.path: ${stringField(globalConfig, 'perl_path') ?? '(unconfigured)'}`,
+    '',
+    'Setup hints',
+    `- status: ${stringField(setupHints, 'status') ?? 'unknown'}`,
+    `- hint count: ${numberField(setupHints, 'hint_count') ?? setupHintItems.length}`,
+    `- Perl binary: ${stringField(perlBinary, 'resolution_status') ?? 'unknown'}`,
+    `- Perl version: ${stringField(perlBinary, 'version_status') ?? 'unknown'}`,
+    `- perldoc: ${stringField(perldoc, 'status') ?? 'unknown'}`,
+    `- DAP Perl: ${stringField(dap, 'status') ?? 'unknown'}`,
+    '',
+    'Client runtime state',
+    `- source: ${stringField(clientRuntime, 'source') ?? 'unknown'}`,
+    `- perldoc surface: ${stringField(clientPerldoc, 'status') ?? 'unknown'}`,
+    `- DAP adapter: ${stringField(clientDap, 'status') ?? 'unknown'}`,
+    `- DAP managed adapter exists: ${String(booleanField(clientDap, 'managed_adapter_exists') ?? false)}`,
+    `- DAP active Perl session: ${String(booleanField(clientDap, 'active_perl_debug_session') ?? false)}`,
+    `- DAP launch.json workspaces: ${numberField(clientDap, 'launch_json_workspace_count') ?? 0}`,
+    `- DAP launch configs: ${numberField(launchConfiguration, 'configuration_count') ?? 0}`,
+    `- DAP Perl configs: ${numberField(launchConfiguration, 'perl_configuration_count') ?? 0}`,
+    `- DAP includePaths configs: ${numberField(launchConfiguration, 'include_paths_configured_count') ?? 0}`,
+    `- DAP includePaths entries: ${numberField(launchConfiguration, 'include_path_entry_count') ?? 0}`,
+    `- DAP perlPath configs: ${numberField(launchConfiguration, 'perl_path_configured_count') ?? 0}`,
+  ];
+
+  for (const item of setupHintItems.slice(0, 5)) {
+    const hint = asObject(item);
+    if (!hint) {
+      continue;
+    }
+    const severity = stringField(hint, 'severity') ?? 'info';
+    const message = stringField(hint, 'message') ?? 'Setup hint did not include a message.';
+    lines.push(`- ${severity}: ${message}`);
+    const action = stringField(hint, 'action');
+    if (action) {
+      lines.push(`  action: ${action}`);
+    }
+  }
+
+  const setupBoundary = stringField(setupHints, 'claim_boundary');
+  if (setupBoundary) {
+    lines.push(`- boundary: ${setupBoundary}`);
+  }
+  const launchConfigBoundary = stringField(launchConfiguration, 'claim_boundary');
+  if (launchConfigBoundary) {
+    lines.push(`- launch config boundary: ${launchConfigBoundary}`);
+  }
+
+  lines.push(
+    '',
+    'Index',
+    `- state: ${indexState}`,
+    `- availability: ${indexAvailability}`,
+    `- indexed files: ${indexedFileCount}`,
+    `- indexed symbols: ${indexedSymbolCount}`,
+    '',
+    'Provider support tiers',
+  );
+  appendSupportTierLines(lines, supportTiers);
+
+  lines.push(
+    '',
+    'Provider decision traces',
+    `- persisted trace keys: ${traceCount}`,
+    '',
+    'Dynamic boundaries',
+    `- ${stringField(dynamicBoundaries, 'policy') ?? 'Generated, dynamic, stale, low-confidence, ambiguous, and fallback facts remain bounded by provider policy.'}`,
+    '',
+    'Claim boundary',
+    stringField(report, 'claim_boundary') ?? 'This report is bounded to current runtime state.',
+    '',
+    'Raw report JSON',
+    providerDecisionJson(result),
+  );
+
+  return lines.join('\n');
+}
+
+function formatMissingModuleLookup(result: unknown): string {
+  const report = asObject(result);
+  const moduleResolution = asObject(report?.module_resolution);
+  const lookupResult = asObject(moduleResolution?.result);
+  const includePaths = arrayField(moduleResolution, 'effective_include_paths');
+
+  const lines = [
+    'Perl LSP Missing Module Lookup',
+    '',
+    `Module: ${stringField(report, 'requested_module') ?? '(unknown)'}`,
+    `Expected path: ${stringField(report, 'expected_relative_path') ?? '(unknown)'}`,
+    `Result: ${stringField(lookupResult, 'status') ?? 'unknown'}`,
+    `Why: ${stringField(lookupResult, 'why') ?? 'No lookup reason reported.'}`,
+    '',
+    'Module resolution / @INC',
+    `- PERL5LIB policy: ${stringField(moduleResolution, 'perl5lib_policy') ?? 'unknown'}`,
+    `- system @INC enabled: ${String(booleanField(moduleResolution, 'use_system_inc') ?? false)}`,
+    `- include roots: ${includePaths.length}`,
+  ];
+
+  for (const entry of includePaths.slice(0, 8)) {
+    const root = asObject(entry);
+    if (!root) {
+      continue;
+    }
+
+    const source = stringField(root, 'source') ?? 'unknown source';
+    const kind = stringField(root, 'kind') ?? 'unknown kind';
+    lines.push(`- ${stringField(root, 'path') ?? '(unknown path)'} (${source}, ${kind})`);
+
+    for (const candidate of arrayField(root, 'candidate_paths').slice(0, 2)) {
+      const candidateObject = asObject(candidate);
+      if (!candidateObject) {
+        continue;
+      }
+      const exists = booleanField(candidateObject, 'exists') === true ? 'exists' : 'missing';
+      lines.push(`  candidate: ${stringField(candidateObject, 'path') ?? '(unknown)'} [${exists}]`);
+    }
+  }
+
+  if (includePaths.length > 8) {
+    lines.push(`- ... and ${includePaths.length - 8} more include roots`);
+  }
+
+  lines.push(
+    '',
+    'Claim boundary',
+    stringField(report, 'claim_boundary') ??
+      'This explanation is bounded to current runtime state.',
+    '',
+    'Raw lookup JSON',
+    providerDecisionJson(result),
+  );
+
+  return lines.join('\n');
+}
+
+export async function showWorkspaceTrustReportCommand(
+  activeClient: LspExecuteCommandClient | undefined,
+  clientRuntimeState: () => Record<string, unknown> = workspaceTrustClientRuntimeState,
+  options: DiagnosticCommandOptions = {},
+): Promise<void> {
+  const result = await executeLspCommand(
+    activeClient,
+    'perl.workspaceTrustReport',
+    { client_runtime_state: clientRuntimeState() },
+    options,
+  );
+  if (result === undefined) {
+    return;
+  }
+
+  const channel = outputChannel(options);
+  channel.appendLine('');
+  channel.appendLine(formatWorkspaceTrustReport(result));
+  channel.show();
+}
+
+export async function explainMissingModuleLookupCommand(
+  activeClient: LspExecuteCommandClient | undefined,
+  moduleOverride?: string,
+  options: DiagnosticCommandOptions = {},
+): Promise<unknown | undefined> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== 'perl') {
+    vscode.window.showErrorMessage('Explain Missing Module Lookup requires an active Perl file.');
+    return undefined;
+  }
+
+  const moduleName =
+    moduleOverride ??
+    moduleNameAtCursor(editor) ??
+    (await vscode.window.showInputBox({
+      placeHolder: 'Missing::Module',
+      prompt: 'Module name to explain with perl-lsp @INC lookup state',
+      validateInput: (value) => {
+        if (!value.trim()) {
+          return 'Enter a Perl module name.';
+        }
+        return isPerlModuleName(value.trim()) ? undefined : 'Enter a valid Perl module name.';
+      },
+    }));
+  if (!moduleName) {
+    return undefined;
+  }
+
+  const result = await executeLspCommand(
+    activeClient,
+    'perl.explainMissingModuleLookup',
+    {
+      module: moduleName.trim(),
+      textDocument: { uri: editor.document.uri.toString() },
+      position: {
+        line: editor.selection.active.line,
+        character: editor.selection.active.character,
+      },
+    },
+    options,
+  );
+  if (result === undefined) {
+    return undefined;
+  }
+
+  const resultObject = asObject(result);
+  const message = stringField(resultObject, 'user_message') ?? 'Missing-module lookup explained.';
+  const status = stringField(asObject(asObject(resultObject?.module_resolution)?.result), 'status');
+  const channel = outputChannel(options);
+  channel.appendLine('');
+  channel.appendLine(formatMissingModuleLookup(result));
+
+  const action =
+    status === 'resolved'
+      ? await vscode.window.showInformationMessage(message, 'Show Output')
+      : await vscode.window.showWarningMessage(message, 'Show Output');
+
+  if (action === 'Show Output') {
+    channel.show();
+  }
+
+  return result;
+}
+
+export async function explainProviderDecisionCommand(
+  activeClient: LspExecuteCommandClient | undefined,
+  providerOverride?: string,
+  options: DiagnosticCommandOptions = {},
+): Promise<void> {
+  const provider = await chooseProvider(providerOverride);
+  if (!provider) {
+    return;
+  }
+
+  const result = await executeLspCommand(
+    activeClient,
+    'perl.explainProviderDecision',
+    providerDecisionArgument(provider),
+    options,
+  );
+  if (result !== undefined) {
+    await showProviderDecisionResult('Provider decision explanation', result, options);
+  }
+}
+
+export async function explainDiagnosticCommand(
+  activeClient: LspExecuteCommandClient | undefined,
+  request?: unknown,
+  options: DiagnosticCommandOptions = {},
+): Promise<void> {
+  const requestObject = asObject(request);
+  const argument: Record<string, unknown> = requestObject
+    ? { ...requestObject }
+    : providerDecisionArgument('diagnostics');
+
+  if (typeof argument.provider !== 'string') {
+    argument.provider = 'diagnostics';
+  }
+
+  const result = await executeLspCommand(
+    activeClient,
+    'perl.explainProviderDecision',
+    argument,
+    options,
+  );
+  if (result !== undefined) {
+    await showProviderDecisionResult('Diagnostic explanation', result, options);
+  }
+}
+
+export async function previewSafeDeleteCommand(
+  activeClient: LspExecuteCommandClient | undefined,
+  options: DiagnosticCommandOptions = {},
+): Promise<void> {
+  const argument = activeSafeDeletePreviewArgument();
+  if (!argument) {
+    vscode.window.showErrorMessage('Preview Safe Delete requires an active Perl file.');
+    return;
+  }
+
+  const result = await executeLspCommand(activeClient, 'perl.previewSafeDelete', argument, options);
+  if (result !== undefined) {
+    await showProviderDecisionResult('Safe-delete preview', result, options);
+  }
+}
+
+export async function previewPackageRenameCommand(
+  activeClient: LspExecuteCommandClient | undefined,
+  options: DiagnosticCommandOptions = {},
+): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== 'perl') {
+    vscode.window.showErrorMessage('Preview Package Rename requires an active Perl file.');
+    return;
+  }
+
+  const argument = await activePackageRenamePreviewArgument();
+  if (!argument) {
+    return;
+  }
+
+  const result = await executeLspCommand(
+    activeClient,
+    'perl.previewPackageRename',
+    argument,
+    options,
+  );
+  if (result !== undefined) {
+    await showProviderDecisionResult('Package rename preview', result, options);
+  }
+}
+
+async function activePackageRenamePreviewArgument(): Promise<Record<string, unknown> | undefined> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== 'perl') {
+    return undefined;
+  }
+
+  const selectedText = editor.selection.isEmpty
+    ? ''
+    : editor.document.getText(editor.selection).trim();
+  const wordRange = editor.document.getWordRangeAtPosition(editor.selection.active);
+  const wordText = wordRange ? editor.document.getText(wordRange).trim() : '';
+  const defaultValue = selectedText || wordText;
+
+  const newName = await vscode.window.showInputBox({
+    value: defaultValue,
+    placeHolder: 'renamed_symbol',
+    prompt: 'New package or symbol name for the no-edit rename preview',
+    validateInput: (value) => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return 'Enter a new Perl package or symbol name.';
+      }
+      return isPerlModuleName(trimmed) ? undefined : 'Use a single Perl package or symbol name.';
+    },
+  });
+  if (!newName) {
+    return undefined;
+  }
+
+  return {
+    textDocument: { uri: editor.document.uri.toString() },
+    position: {
+      line: editor.selection.active.line,
+      character: editor.selection.active.character,
+    },
+    newName: newName.trim(),
+  };
+}
+
+export async function copyProviderDecisionReceiptCommand(
+  activeClient: LspExecuteCommandClient | undefined,
+  providerOverride?: string,
+  options: DiagnosticCommandOptions = {},
+): Promise<void> {
+  const provider = await chooseProvider(providerOverride);
+  if (!provider) {
+    return;
+  }
+
+  const result = await executeLspCommand(
+    activeClient,
+    'perl.explainProviderDecision',
+    providerDecisionArgument(provider),
+    options,
+  );
+  const resultObject = asObject(result);
+  if (!resultObject) {
+    return;
+  }
+
+  const payload = resultObject.copyable_payload ?? resultObject;
+  await vscode.env.clipboard.writeText(providerDecisionJson(payload));
+  vscode.window.showInformationMessage('Provider decision receipt copied.');
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,7 +16,6 @@ import type {
 import { PerlTestAdapter } from './testAdapter';
 import {
   activateDebugger,
-  hasLaunchJson,
   rewriteTestLensCommand,
   parseDebugTestLaunchTarget,
 } from './debugAdapter';
@@ -70,7 +69,8 @@ import {
   type FeatureActivationMetricsSnapshot,
 } from './featureActivationMetrics';
 import { registerWorkspaceConfigurationEvents } from './extensionWorkspaceEvents';
-import { describeWorkspaceTopology } from './workspaceTopology';
+import { workspaceTrustClientRuntimeState } from './workspaceTrustRuntimeState';
+export { workspaceTrustClientRuntimeState } from './workspaceTrustRuntimeState';
 import {
   buildDisabledFeaturesFromConfig,
   buildPerlCriticConfiguration as buildPerlCriticConfigurationPayload,
@@ -473,170 +473,6 @@ function arrayField(value: Record<string, unknown> | undefined, field: string): 
 
 function providerDecisionJson(value: unknown): string {
   return JSON.stringify(value, null, 2);
-}
-
-function incrementCount(target: Record<string, number>, key: string): void {
-  target[key] = (target[key] ?? 0) + 1;
-}
-
-function classifyLaunchPath(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return 'empty';
-  }
-  if (trimmed.includes('${workspaceFolder')) {
-    return 'workspace_variable';
-  }
-  if (trimmed.includes('${file')) {
-    return 'file_variable';
-  }
-  if (/\$\{[^}]+}/.test(trimmed)) {
-    return 'other_variable';
-  }
-  if (trimmed.startsWith('~')) {
-    return 'home_relative';
-  }
-  if (path.isAbsolute(trimmed)) {
-    return 'absolute';
-  }
-  if (!trimmed.includes('/') && !trimmed.includes('\\')) {
-    return 'command';
-  }
-  return 'relative';
-}
-
-function collectLaunchConfigurationState(
-  workspaceFolders: readonly vscode.WorkspaceFolder[],
-): Record<string, unknown> {
-  const includePathKindCounts: Record<string, number> = {};
-  const perlPathKindCounts: Record<string, number> = {};
-  const programPathKindCounts: Record<string, number> = {};
-  const cwdPathKindCounts: Record<string, number> = {};
-  let configurationCount = 0;
-  let perlConfigurationCount = 0;
-  let launchRequestCount = 0;
-  let attachRequestCount = 0;
-  let perlPathConfiguredCount = 0;
-  let includePathsConfiguredCount = 0;
-  let includePathEntryCount = 0;
-  let nonStringIncludePathCount = 0;
-  let programConfiguredCount = 0;
-  let cwdConfiguredCount = 0;
-
-  for (const folder of workspaceFolders) {
-    const launchConfigurations = vscode.workspace
-      .getConfiguration('launch', folder.uri)
-      .get<unknown[]>('configurations', []);
-    if (!Array.isArray(launchConfigurations)) {
-      continue;
-    }
-
-    for (const entry of launchConfigurations) {
-      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
-        continue;
-      }
-
-      configurationCount += 1;
-      const config = entry as Record<string, unknown>;
-      if (config.type !== 'perl') {
-        continue;
-      }
-
-      perlConfigurationCount += 1;
-      if (config.request === 'launch') {
-        launchRequestCount += 1;
-      } else if (config.request === 'attach') {
-        attachRequestCount += 1;
-      }
-
-      if (typeof config.perlPath === 'string') {
-        perlPathConfiguredCount += 1;
-        incrementCount(perlPathKindCounts, classifyLaunchPath(config.perlPath));
-      }
-
-      if (typeof config.program === 'string') {
-        programConfiguredCount += 1;
-        incrementCount(programPathKindCounts, classifyLaunchPath(config.program));
-      }
-
-      if (typeof config.cwd === 'string') {
-        cwdConfiguredCount += 1;
-        incrementCount(cwdPathKindCounts, classifyLaunchPath(config.cwd));
-      }
-
-      if (Array.isArray(config.includePaths)) {
-        includePathsConfiguredCount += 1;
-        for (const includePath of config.includePaths) {
-          if (typeof includePath !== 'string') {
-            nonStringIncludePathCount += 1;
-            continue;
-          }
-          includePathEntryCount += 1;
-          incrementCount(includePathKindCounts, classifyLaunchPath(includePath));
-        }
-      }
-    }
-  }
-
-  return {
-    status: 'client_launch_config_reported',
-    configuration_count: configurationCount,
-    perl_configuration_count: perlConfigurationCount,
-    launch_request_count: launchRequestCount,
-    attach_request_count: attachRequestCount,
-    perl_path_configured_count: perlPathConfiguredCount,
-    include_paths_configured_count: includePathsConfiguredCount,
-    include_path_entry_count: includePathEntryCount,
-    non_string_include_path_count: nonStringIncludePathCount,
-    program_configured_count: programConfiguredCount,
-    cwd_configured_count: cwdConfiguredCount,
-    include_path_kind_counts: includePathKindCounts,
-    perl_path_kind_counts: perlPathKindCounts,
-    program_path_kind_counts: programPathKindCounts,
-    cwd_path_kind_counts: cwdPathKindCounts,
-    claim_boundary:
-      'Launch configuration state is summarized from VS Code configuration only. It reports counts and path classes, not raw paths, and does not start DAP, resolve Perl, probe modules, or change debug behavior.',
-  };
-}
-
-export function workspaceTrustClientRuntimeState(
-  context?: vscode.ExtensionContext,
-): Record<string, unknown> {
-  const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
-  const managedDapPath = context ? BinaryDownloader.getLocalDapPath(context) : undefined;
-  const managedAdapterExists = managedDapPath ? fs.existsSync(managedDapPath) : false;
-  const launchJsonWorkspaceCount = workspaceFolders.filter((folder) =>
-    hasLaunchJson(folder.uri.fsPath),
-  ).length;
-  const activeDebugSession = vscode.debug.activeDebugSession;
-  const topology = describeWorkspaceTopology({
-    folders: workspaceFolders,
-    documents: vscode.workspace.textDocuments,
-    isTrusted: vscode.workspace.isTrusted,
-    remoteName: vscode.env.remoteName,
-  });
-
-  return {
-    schema_version: 'workspace_trust_client_runtime.v1',
-    source: 'vscode-extension',
-    perldoc: {
-      status: 'client_surface_registered',
-      uri_scheme: 'perldoc',
-      client_surface: 'perldoc virtual documents are served by the LSP textDocumentContent path',
-    },
-    dap: {
-      status: 'client_state_reported',
-      adapter_registered: true,
-      active_perl_debug_session: activeDebugSession?.type === 'perl',
-      managed_adapter_exists: managedAdapterExists,
-      launch_json_workspace_count: launchJsonWorkspaceCount,
-      workspace_folder_count: workspaceFolders.length,
-      launch_configuration: collectLaunchConfigurationState(workspaceFolders),
-    },
-    topology,
-    claim_boundary:
-      'VS Code client runtime state reads extension/debugger state only. It does not start DAP, run perldoc, probe Perl, or change provider behavior.',
-  };
 }
 
 async function executeLspCommand(

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -53,6 +53,16 @@ import { registerTestCommandGroup } from './testCommandGroup';
 import { registerOnboardingCommandGroup } from './onboardingCommandGroup';
 import { registerNavigationCommandGroup } from './navigationCommandGroup';
 import { registerDiagnosticCommandGroup } from './diagnosticCommandGroup';
+import {
+  copyProviderDecisionReceiptCommand as copyProviderDecisionReceipt,
+  explainDiagnosticCommand as explainDiagnostic,
+  explainMissingModuleLookupCommand as explainMissingModuleLookup,
+  explainProviderDecisionCommand as explainProviderDecision,
+  previewPackageRenameCommand as previewPackageRename,
+  previewSafeDeleteCommand as previewSafeDelete,
+  showWorkspaceTrustReportCommand as showWorkspaceTrustReport,
+} from './diagnosticCommands';
+import type { DiagnosticCommandOptions, LspExecuteCommandClient } from './diagnosticCommands';
 import { registerDocumentCommandGroup } from './documentCommandGroup';
 import { registerRefactoringCommandGroup } from './refactoringCommandGroup';
 import { registerSupportCommandGroup } from './supportCommandGroup';
@@ -305,595 +315,60 @@ export async function setPerlCriticSeverity(
   vscode.window.showInformationMessage(`Critic severity set to ${severity}.`);
 }
 
-type LspExecuteCommandClient = {
-  sendRequest<T>(method: string, params: unknown): Promise<T>;
-};
+type DiagnosticCommandOptionsWithDefaults = DiagnosticCommandOptions;
 
-type ProviderDecisionQuickPickItem = vscode.QuickPickItem & {
-  provider: string;
-};
-
-const PROVIDER_DECISION_OPTIONS: ProviderDecisionQuickPickItem[] = [
-  { label: 'Completion', provider: 'completion' },
-  { label: 'Goto definition', provider: 'goto_definition' },
-  { label: 'References', provider: 'references' },
-  { label: 'Hover', provider: 'hover' },
-  { label: 'Diagnostics', provider: 'diagnostics' },
-  { label: 'Rename', provider: 'rename' },
-  { label: 'Safe delete', provider: 'safe_delete' },
-  { label: 'Workspace symbols', provider: 'workspace_symbols' },
-  { label: 'Document symbols', provider: 'document_symbols' },
-  { label: 'Semantic tokens', provider: 'semantic_tokens' },
-  { label: 'Module resolution', provider: 'module_resolution' },
-  { label: 'DAP module paths', provider: 'dap_module_paths' },
-  { label: 'Perl subprocess', provider: 'perl_subprocess' },
-];
-
-function activeRequestPosition(): Record<string, unknown> | undefined {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) {
-    return undefined;
-  }
-
+function diagnosticCommandOptions(): DiagnosticCommandOptionsWithDefaults {
   return {
-    uri_scheme: editor.document.uri.toString().split(':', 1)[0] || 'file',
-    line: editor.selection.active.line,
-    character: editor.selection.active.character,
+    outputChannel,
+    serverNotRunningMessage,
   };
-}
-
-function providerDecisionArgument(provider: string): Record<string, unknown> {
-  const argument: Record<string, unknown> = { provider };
-  const requestPosition = activeRequestPosition();
-  if (requestPosition) {
-    argument.request_position = requestPosition;
-  }
-  return argument;
-}
-
-function activeSafeDeletePreviewArgument(): Record<string, unknown> | undefined {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor || editor.document.languageId !== 'perl') {
-    return undefined;
-  }
-
-  return {
-    textDocument: { uri: editor.document.uri.toString() },
-    position: {
-      line: editor.selection.active.line,
-      character: editor.selection.active.character,
-    },
-  };
-}
-
-async function activePackageRenamePreviewArgument(): Promise<Record<string, unknown> | undefined> {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor || editor.document.languageId !== 'perl') {
-    return undefined;
-  }
-
-  const selectedText = editor.selection.isEmpty
-    ? ''
-    : editor.document.getText(editor.selection).trim();
-  const wordRange = editor.document.getWordRangeAtPosition(editor.selection.active);
-  const wordText = wordRange ? editor.document.getText(wordRange).trim() : '';
-  const defaultValue = selectedText || wordText;
-
-  const newName = await vscode.window.showInputBox({
-    value: defaultValue,
-    placeHolder: 'renamed_symbol',
-    prompt: 'New package or symbol name for the no-edit rename preview',
-    validateInput: (value) => {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return 'Enter a new Perl package or symbol name.';
-      }
-      return isPerlModuleName(trimmed) ? undefined : 'Use a single Perl package or symbol name.';
-    },
-  });
-  if (!newName) {
-    return undefined;
-  }
-
-  return {
-    textDocument: { uri: editor.document.uri.toString() },
-    position: {
-      line: editor.selection.active.line,
-      character: editor.selection.active.character,
-    },
-    newName: newName.trim(),
-  };
-}
-
-function isPerlModuleName(value: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$/.test(value);
-}
-
-function moduleNameAtCursor(editor: vscode.TextEditor): string | undefined {
-  const selectedText = editor.document.getText(editor.selection).trim();
-  if (isPerlModuleName(selectedText)) {
-    return selectedText;
-  }
-
-  const active = editor.selection.active;
-  const lineText = editor.document.lineAt(active.line).text;
-  const modulePattern = /[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)+/g;
-  for (const match of lineText.matchAll(modulePattern)) {
-    const start = match.index ?? 0;
-    const end = start + match[0].length;
-    if (active.character >= start && active.character <= end) {
-      return match[0];
-    }
-  }
-
-  const useStatement = lineText.match(
-    /\b(?:use|require)\s+([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)/,
-  );
-  return useStatement?.[1];
-}
-
-function trustOutputChannel(): vscode.OutputChannel {
-  return outputChannel ?? vscode.window.createOutputChannel('Perl LSP Trust');
-}
-
-function asObject(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function stringField(
-  value: Record<string, unknown> | undefined,
-  field: string,
-): string | undefined {
-  const fieldValue = value?.[field];
-  return typeof fieldValue === 'string' ? fieldValue : undefined;
-}
-
-function numberField(
-  value: Record<string, unknown> | undefined,
-  field: string,
-): number | undefined {
-  const fieldValue = value?.[field];
-  return typeof fieldValue === 'number' ? fieldValue : undefined;
-}
-
-function booleanField(
-  value: Record<string, unknown> | undefined,
-  field: string,
-): boolean | undefined {
-  const fieldValue = value?.[field];
-  return typeof fieldValue === 'boolean' ? fieldValue : undefined;
-}
-
-function arrayField(value: Record<string, unknown> | undefined, field: string): unknown[] {
-  const fieldValue = value?.[field];
-  return Array.isArray(fieldValue) ? fieldValue : [];
-}
-
-function providerDecisionJson(value: unknown): string {
-  return JSON.stringify(value, null, 2);
-}
-
-async function executeLspCommand(
-  activeClient: LspExecuteCommandClient | undefined,
-  command: string,
-  argument?: Record<string, unknown>,
-): Promise<unknown | undefined> {
-  if (!activeClient) {
-    vscode.window.showWarningMessage(serverNotRunningMessage());
-    return undefined;
-  }
-
-  try {
-    return await activeClient.sendRequest('workspace/executeCommand', {
-      command,
-      arguments: argument === undefined ? [] : [argument],
-    });
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    vscode.window.showErrorMessage(`Perl LSP command failed: ${message}`);
-    return undefined;
-  }
-}
-
-async function chooseProvider(providerOverride?: string): Promise<string | undefined> {
-  if (providerOverride) {
-    return providerOverride;
-  }
-
-  const selection = await vscode.window.showQuickPick(PROVIDER_DECISION_OPTIONS, {
-    placeHolder: 'Choose a provider decision to explain',
-  });
-  return selection?.provider;
-}
-
-async function showProviderDecisionResult(title: string, result: unknown): Promise<void> {
-  const resultObject = asObject(result);
-  const message = stringField(resultObject, 'user_message') ?? `${title} completed.`;
-  const channel = trustOutputChannel();
-  channel.appendLine('');
-  channel.appendLine(`[${title}]`);
-  channel.appendLine(providerDecisionJson(result));
-
-  const action =
-    stringField(resultObject, 'decision') === 'blocked'
-      ? await vscode.window.showWarningMessage(message, 'Show Output')
-      : await vscode.window.showInformationMessage(message, 'Show Output');
-
-  if (action === 'Show Output') {
-    channel.show();
-  }
-}
-
-function appendSupportTierLines(
-  lines: string[],
-  supportTiers: Record<string, unknown> | undefined,
-): void {
-  if (!supportTiers) {
-    lines.push('- support tiers: unavailable');
-    return;
-  }
-
-  for (const [surface, tier] of Object.entries(supportTiers).sort(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
-    if (typeof tier === 'string') {
-      lines.push(`- ${surface}: ${tier}`);
-    }
-  }
-}
-
-function formatWorkspaceTrustReport(result: unknown): string {
-  const report = asObject(result);
-  const workspace = asObject(report?.workspace);
-  const moduleResolution = asObject(report?.module_resolution);
-  const globalConfig = asObject(moduleResolution?.global_workspace_config);
-  const index = asObject(report?.index);
-  const providers = asObject(report?.providers);
-  const supportTiers = asObject(providers?.support_tiers);
-  const dynamicBoundaries = asObject(report?.dynamic_boundaries);
-  const setupHints = asObject(report?.setup_hints);
-  const clientRuntime = asObject(report?.client_runtime_state);
-  const setupHintItems = arrayField(setupHints, 'hints');
-  const perlBinary = asObject(setupHints?.perl_binary);
-  const perldoc = asObject(setupHints?.perldoc);
-  const dap = asObject(setupHints?.dap);
-  const clientPerldoc = asObject(clientRuntime?.perldoc);
-  const clientDap = asObject(clientRuntime?.dap);
-  const launchConfiguration = asObject(clientDap?.launch_configuration);
-
-  const rootPath = stringField(workspace, 'root_path') ?? '(none)';
-  const folderCount = numberField(workspace, 'workspace_folder_count') ?? 0;
-  const openDocumentCount = numberField(workspace, 'open_document_count') ?? 0;
-  const includePaths = arrayField(globalConfig, 'include_paths');
-  const effectiveIncludePaths = arrayField(globalConfig, 'effective_include_paths');
-  const usePerl5lib = booleanField(globalConfig, 'use_perl5lib');
-  const perl5libCount = numberField(globalConfig, 'perl5lib_entry_count') ?? 0;
-  const indexState = stringField(index, 'state') ?? 'unknown';
-  const indexAvailability = stringField(index, 'availability') ?? 'unknown';
-  const indexedFileCount = numberField(index, 'indexed_file_count') ?? 0;
-  const indexedSymbolCount = numberField(index, 'indexed_symbol_count') ?? 0;
-  const traceCount = numberField(providers, 'decision_trace_count') ?? 0;
-
-  const lines = [
-    'Perl LSP Trust Report',
-    '',
-    `Schema: ${stringField(report, 'schema_version') ?? 'unknown'}`,
-    `Root: ${rootPath}`,
-    `Workspace folders: ${folderCount}`,
-    `Open documents: ${openDocumentCount}`,
-    '',
-    'Module resolution / @INC',
-    `- configured include paths: ${includePaths.length}`,
-    `- effective include paths: ${effectiveIncludePaths.length}`,
-    `- system @INC: ${stringField(globalConfig, 'system_inc_status') ?? 'unknown'}`,
-    `- PERL5LIB enabled: ${usePerl5lib === undefined ? 'unknown' : String(usePerl5lib)}`,
-    `- PERL5LIB entries: ${perl5libCount}`,
-    `- perl.path: ${stringField(globalConfig, 'perl_path') ?? '(unconfigured)'}`,
-    '',
-    'Setup hints',
-    `- status: ${stringField(setupHints, 'status') ?? 'unknown'}`,
-    `- hint count: ${numberField(setupHints, 'hint_count') ?? setupHintItems.length}`,
-    `- Perl binary: ${stringField(perlBinary, 'resolution_status') ?? 'unknown'}`,
-    `- Perl version: ${stringField(perlBinary, 'version_status') ?? 'unknown'}`,
-    `- perldoc: ${stringField(perldoc, 'status') ?? 'unknown'}`,
-    `- DAP Perl: ${stringField(dap, 'status') ?? 'unknown'}`,
-    '',
-    'Client runtime state',
-    `- source: ${stringField(clientRuntime, 'source') ?? 'unknown'}`,
-    `- perldoc surface: ${stringField(clientPerldoc, 'status') ?? 'unknown'}`,
-    `- DAP adapter: ${stringField(clientDap, 'status') ?? 'unknown'}`,
-    `- DAP managed adapter exists: ${String(booleanField(clientDap, 'managed_adapter_exists') ?? false)}`,
-    `- DAP active Perl session: ${String(booleanField(clientDap, 'active_perl_debug_session') ?? false)}`,
-    `- DAP launch.json workspaces: ${numberField(clientDap, 'launch_json_workspace_count') ?? 0}`,
-    `- DAP launch configs: ${numberField(launchConfiguration, 'configuration_count') ?? 0}`,
-    `- DAP Perl configs: ${numberField(launchConfiguration, 'perl_configuration_count') ?? 0}`,
-    `- DAP includePaths configs: ${numberField(launchConfiguration, 'include_paths_configured_count') ?? 0}`,
-    `- DAP includePaths entries: ${numberField(launchConfiguration, 'include_path_entry_count') ?? 0}`,
-    `- DAP perlPath configs: ${numberField(launchConfiguration, 'perl_path_configured_count') ?? 0}`,
-  ];
-
-  for (const item of setupHintItems.slice(0, 5)) {
-    const hint = asObject(item);
-    if (!hint) {
-      continue;
-    }
-    const severity = stringField(hint, 'severity') ?? 'info';
-    const message = stringField(hint, 'message') ?? 'Setup hint did not include a message.';
-    lines.push(`- ${severity}: ${message}`);
-    const action = stringField(hint, 'action');
-    if (action) {
-      lines.push(`  action: ${action}`);
-    }
-  }
-
-  const setupBoundary = stringField(setupHints, 'claim_boundary');
-  if (setupBoundary) {
-    lines.push(`- boundary: ${setupBoundary}`);
-  }
-  const launchConfigBoundary = stringField(launchConfiguration, 'claim_boundary');
-  if (launchConfigBoundary) {
-    lines.push(`- launch config boundary: ${launchConfigBoundary}`);
-  }
-
-  lines.push(
-    '',
-    'Index',
-    `- state: ${indexState}`,
-    `- availability: ${indexAvailability}`,
-    `- indexed files: ${indexedFileCount}`,
-    `- indexed symbols: ${indexedSymbolCount}`,
-    '',
-    'Provider support tiers',
-  );
-  appendSupportTierLines(lines, supportTiers);
-
-  lines.push(
-    '',
-    'Provider decision traces',
-    `- persisted trace keys: ${traceCount}`,
-    '',
-    'Dynamic boundaries',
-    `- ${stringField(dynamicBoundaries, 'policy') ?? 'Generated, dynamic, stale, low-confidence, ambiguous, and fallback facts remain bounded by provider policy.'}`,
-    '',
-    'Claim boundary',
-    stringField(report, 'claim_boundary') ?? 'This report is bounded to current runtime state.',
-    '',
-    'Raw report JSON',
-    providerDecisionJson(result),
-  );
-
-  return lines.join('\n');
-}
-
-function formatMissingModuleLookup(result: unknown): string {
-  const report = asObject(result);
-  const moduleResolution = asObject(report?.module_resolution);
-  const lookupResult = asObject(moduleResolution?.result);
-  const includePaths = arrayField(moduleResolution, 'effective_include_paths');
-
-  const lines = [
-    'Perl LSP Missing Module Lookup',
-    '',
-    `Module: ${stringField(report, 'requested_module') ?? '(unknown)'}`,
-    `Expected path: ${stringField(report, 'expected_relative_path') ?? '(unknown)'}`,
-    `Result: ${stringField(lookupResult, 'status') ?? 'unknown'}`,
-    `Why: ${stringField(lookupResult, 'why') ?? 'No lookup reason reported.'}`,
-    '',
-    'Module resolution / @INC',
-    `- PERL5LIB policy: ${stringField(moduleResolution, 'perl5lib_policy') ?? 'unknown'}`,
-    `- system @INC enabled: ${String(booleanField(moduleResolution, 'use_system_inc') ?? false)}`,
-    `- include roots: ${includePaths.length}`,
-  ];
-
-  for (const entry of includePaths.slice(0, 8)) {
-    const root = asObject(entry);
-    if (!root) {
-      continue;
-    }
-
-    const source = stringField(root, 'source') ?? 'unknown source';
-    const kind = stringField(root, 'kind') ?? 'unknown kind';
-    lines.push(`- ${stringField(root, 'path') ?? '(unknown path)'} (${source}, ${kind})`);
-
-    for (const candidate of arrayField(root, 'candidate_paths').slice(0, 2)) {
-      const candidateObject = asObject(candidate);
-      if (!candidateObject) {
-        continue;
-      }
-      const exists = booleanField(candidateObject, 'exists') === true ? 'exists' : 'missing';
-      lines.push(`  candidate: ${stringField(candidateObject, 'path') ?? '(unknown)'} [${exists}]`);
-    }
-  }
-
-  if (includePaths.length > 8) {
-    lines.push(`- ... and ${includePaths.length - 8} more include roots`);
-  }
-
-  lines.push(
-    '',
-    'Claim boundary',
-    stringField(report, 'claim_boundary') ??
-      'This explanation is bounded to current runtime state.',
-    '',
-    'Raw lookup JSON',
-    providerDecisionJson(result),
-  );
-
-  return lines.join('\n');
 }
 
 export async function showWorkspaceTrustReportCommand(
   activeClient: LspExecuteCommandClient | undefined = client,
   clientRuntimeState: () => Record<string, unknown> = workspaceTrustClientRuntimeState,
 ): Promise<void> {
-  const result = await executeLspCommand(activeClient, 'perl.workspaceTrustReport', {
-    client_runtime_state: clientRuntimeState(),
-  });
-  if (result === undefined) {
-    return;
-  }
-
-  const channel = trustOutputChannel();
-  channel.appendLine('');
-  channel.appendLine(formatWorkspaceTrustReport(result));
-  channel.show();
+  return showWorkspaceTrustReport(activeClient, clientRuntimeState, diagnosticCommandOptions());
 }
 
 export async function explainMissingModuleLookupCommand(
   activeClient: LspExecuteCommandClient | undefined = client,
   moduleOverride?: string,
 ): Promise<unknown | undefined> {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor || editor.document.languageId !== 'perl') {
-    vscode.window.showErrorMessage('Explain Missing Module Lookup requires an active Perl file.');
-    return undefined;
-  }
-
-  const moduleName =
-    moduleOverride ??
-    moduleNameAtCursor(editor) ??
-    (await vscode.window.showInputBox({
-      placeHolder: 'Missing::Module',
-      prompt: 'Module name to explain with perl-lsp @INC lookup state',
-      validateInput: (value) => {
-        if (!value.trim()) {
-          return 'Enter a Perl module name.';
-        }
-        return isPerlModuleName(value.trim()) ? undefined : 'Enter a valid Perl module name.';
-      },
-    }));
-  if (!moduleName) {
-    return undefined;
-  }
-
-  const result = await executeLspCommand(activeClient, 'perl.explainMissingModuleLookup', {
-    module: moduleName.trim(),
-    textDocument: { uri: editor.document.uri.toString() },
-    position: {
-      line: editor.selection.active.line,
-      character: editor.selection.active.character,
-    },
-  });
-  if (result === undefined) {
-    return undefined;
-  }
-
-  const resultObject = asObject(result);
-  const message = stringField(resultObject, 'user_message') ?? 'Missing-module lookup explained.';
-  const status = stringField(asObject(asObject(resultObject?.module_resolution)?.result), 'status');
-  const channel = trustOutputChannel();
-  channel.appendLine('');
-  channel.appendLine(formatMissingModuleLookup(result));
-
-  const action =
-    status === 'resolved'
-      ? await vscode.window.showInformationMessage(message, 'Show Output')
-      : await vscode.window.showWarningMessage(message, 'Show Output');
-
-  if (action === 'Show Output') {
-    channel.show();
-  }
-
-  return result;
+  return explainMissingModuleLookup(activeClient, moduleOverride, diagnosticCommandOptions());
 }
 
 export async function explainProviderDecisionCommand(
   activeClient: LspExecuteCommandClient | undefined = client,
   providerOverride?: string,
 ): Promise<void> {
-  const provider = await chooseProvider(providerOverride);
-  if (!provider) {
-    return;
-  }
-
-  const result = await executeLspCommand(
-    activeClient,
-    'perl.explainProviderDecision',
-    providerDecisionArgument(provider),
-  );
-  if (result !== undefined) {
-    await showProviderDecisionResult('Provider decision explanation', result);
-  }
+  return explainProviderDecision(activeClient, providerOverride, diagnosticCommandOptions());
 }
 
 export async function explainDiagnosticCommand(
   activeClient: LspExecuteCommandClient | undefined = client,
   request?: unknown,
 ): Promise<void> {
-  const requestObject = asObject(request);
-  const argument: Record<string, unknown> = requestObject
-    ? { ...requestObject }
-    : providerDecisionArgument('diagnostics');
-
-  if (typeof argument.provider !== 'string') {
-    argument.provider = 'diagnostics';
-  }
-
-  const result = await executeLspCommand(activeClient, 'perl.explainProviderDecision', argument);
-  if (result !== undefined) {
-    await showProviderDecisionResult('Diagnostic explanation', result);
-  }
+  return explainDiagnostic(activeClient, request, diagnosticCommandOptions());
 }
 
 export async function previewSafeDeleteCommand(
   activeClient: LspExecuteCommandClient | undefined = client,
 ): Promise<void> {
-  const argument = activeSafeDeletePreviewArgument();
-  if (!argument) {
-    vscode.window.showErrorMessage('Preview Safe Delete requires an active Perl file.');
-    return;
-  }
-
-  const result = await executeLspCommand(activeClient, 'perl.previewSafeDelete', argument);
-  if (result !== undefined) {
-    await showProviderDecisionResult('Safe-delete preview', result);
-  }
+  return previewSafeDelete(activeClient, diagnosticCommandOptions());
 }
 
 export async function previewPackageRenameCommand(
   activeClient: LspExecuteCommandClient | undefined = client,
 ): Promise<void> {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor || editor.document.languageId !== 'perl') {
-    vscode.window.showErrorMessage('Preview Package Rename requires an active Perl file.');
-    return;
-  }
-
-  const argument = await activePackageRenamePreviewArgument();
-  if (!argument) {
-    return;
-  }
-
-  const result = await executeLspCommand(activeClient, 'perl.previewPackageRename', argument);
-  if (result !== undefined) {
-    await showProviderDecisionResult('Package rename preview', result);
-  }
+  return previewPackageRename(activeClient, diagnosticCommandOptions());
 }
 
 export async function copyProviderDecisionReceiptCommand(
   activeClient: LspExecuteCommandClient | undefined = client,
   providerOverride?: string,
 ): Promise<void> {
-  const provider = await chooseProvider(providerOverride);
-  if (!provider) {
-    return;
-  }
-
-  const result = await executeLspCommand(
-    activeClient,
-    'perl.explainProviderDecision',
-    providerDecisionArgument(provider),
-  );
-  const resultObject = asObject(result);
-  if (!resultObject) {
-    return;
-  }
-
-  const payload = resultObject.copyable_payload ?? resultObject;
-  await vscode.env.clipboard.writeText(providerDecisionJson(payload));
-  vscode.window.showInformationMessage('Provider decision receipt copied.');
+  return copyProviderDecisionReceipt(activeClient, providerOverride, diagnosticCommandOptions());
 }
 
 export async function activate(context: vscode.ExtensionContext) {

--- a/vscode-extension/src/test/diagnosticCommands.test.ts
+++ b/vscode-extension/src/test/diagnosticCommands.test.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode';
+import {
+  explainDiagnosticCommand,
+  showWorkspaceTrustReportCommand,
+  type LspExecuteCommandClient,
+} from '../diagnosticCommands';
+
+function makeOutputChannel(): vscode.OutputChannel & {
+  appendLine: jest.Mock;
+  show: jest.Mock;
+} {
+  return {
+    appendLine: jest.fn(),
+    show: jest.fn(),
+    dispose: jest.fn(),
+  } as unknown as vscode.OutputChannel & {
+    appendLine: jest.Mock;
+    show: jest.Mock;
+  };
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+  (vscode.window as unknown as { activeTextEditor: unknown }).activeTextEditor = undefined;
+});
+
+describe('diagnostic command implementation boundary', () => {
+  test('uses the injected unavailable-state message without importing extension lifecycle state', async () => {
+    await explainDiagnosticCommand(
+      undefined,
+      { provider: 'diagnostics' },
+      {
+        serverNotRunningMessage: () => 'The language server is still starting.',
+      },
+    );
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      'The language server is still starting.',
+    );
+  });
+
+  test('uses the injected runtime-state supplier and output channel', async () => {
+    const outputChannel = makeOutputChannel();
+    const runtimeState = {
+      schema_version: 'workspace_trust_client_runtime.v1',
+      source: 'vscode-extension',
+    };
+    const sendRequest = jest.fn(async () => ({
+      schema_version: 'workspace_trust_report.v1',
+      workspace: { workspace_folder_count: 1, open_document_count: 0 },
+      client_runtime_state: runtimeState,
+    }));
+
+    await showWorkspaceTrustReportCommand(
+      { sendRequest } as unknown as LspExecuteCommandClient,
+      () => runtimeState,
+      { outputChannel },
+    );
+
+    expect(sendRequest).toHaveBeenCalledWith('workspace/executeCommand', {
+      command: 'perl.workspaceTrustReport',
+      arguments: [{ client_runtime_state: runtimeState }],
+    });
+    expect(outputChannel.appendLine).toHaveBeenCalledWith(
+      expect.stringContaining('Perl LSP Trust Report'),
+    );
+    expect(outputChannel.appendLine).toHaveBeenCalledWith(
+      expect.stringContaining('workspace_trust_report.v1'),
+    );
+    expect(outputChannel.show).toHaveBeenCalledTimes(1);
+  });
+
+  test('reports execute-command failures through the VS Code error surface', async () => {
+    const sendRequest = jest.fn(async () => {
+      throw new Error('request failed');
+    });
+
+    await explainDiagnosticCommand({ sendRequest } as unknown as LspExecuteCommandClient, {
+      provider: 'diagnostics',
+    });
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      'Perl LSP command failed: request failed',
+    );
+  });
+});

--- a/vscode-extension/src/workspaceTrustRuntimeState.ts
+++ b/vscode-extension/src/workspaceTrustRuntimeState.ts
@@ -1,0 +1,170 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { hasLaunchJson } from './debugAdapter';
+import { BinaryDownloader } from './downloader';
+import { describeWorkspaceTopology } from './workspaceTopology';
+
+function incrementCount(target: Record<string, number>, key: string): void {
+  target[key] = (target[key] ?? 0) + 1;
+}
+
+function classifyLaunchPath(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 'empty';
+  }
+  if (trimmed.includes('${workspaceFolder')) {
+    return 'workspace_variable';
+  }
+  if (trimmed.includes('${file')) {
+    return 'file_variable';
+  }
+  if (/\$\{[^}]+}/.test(trimmed)) {
+    return 'other_variable';
+  }
+  if (trimmed.startsWith('~')) {
+    return 'home_relative';
+  }
+  if (path.isAbsolute(trimmed)) {
+    return 'absolute';
+  }
+  if (!trimmed.includes('/') && !trimmed.includes('\\')) {
+    return 'command';
+  }
+  return 'relative';
+}
+
+function collectLaunchConfigurationState(
+  workspaceFolders: readonly vscode.WorkspaceFolder[],
+): Record<string, unknown> {
+  const includePathKindCounts: Record<string, number> = {};
+  const perlPathKindCounts: Record<string, number> = {};
+  const programPathKindCounts: Record<string, number> = {};
+  const cwdPathKindCounts: Record<string, number> = {};
+  let configurationCount = 0;
+  let perlConfigurationCount = 0;
+  let launchRequestCount = 0;
+  let attachRequestCount = 0;
+  let perlPathConfiguredCount = 0;
+  let includePathsConfiguredCount = 0;
+  let includePathEntryCount = 0;
+  let nonStringIncludePathCount = 0;
+  let programConfiguredCount = 0;
+  let cwdConfiguredCount = 0;
+
+  for (const folder of workspaceFolders) {
+    const launchConfigurations = vscode.workspace
+      .getConfiguration('launch', folder.uri)
+      .get<unknown[]>('configurations', []);
+    if (!Array.isArray(launchConfigurations)) {
+      continue;
+    }
+
+    for (const entry of launchConfigurations) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        continue;
+      }
+
+      configurationCount += 1;
+      const config = entry as Record<string, unknown>;
+      if (config.type !== 'perl') {
+        continue;
+      }
+
+      perlConfigurationCount += 1;
+      if (config.request === 'launch') {
+        launchRequestCount += 1;
+      } else if (config.request === 'attach') {
+        attachRequestCount += 1;
+      }
+
+      if (typeof config.perlPath === 'string') {
+        perlPathConfiguredCount += 1;
+        incrementCount(perlPathKindCounts, classifyLaunchPath(config.perlPath));
+      }
+
+      if (typeof config.program === 'string') {
+        programConfiguredCount += 1;
+        incrementCount(programPathKindCounts, classifyLaunchPath(config.program));
+      }
+
+      if (typeof config.cwd === 'string') {
+        cwdConfiguredCount += 1;
+        incrementCount(cwdPathKindCounts, classifyLaunchPath(config.cwd));
+      }
+
+      if (Array.isArray(config.includePaths)) {
+        includePathsConfiguredCount += 1;
+        for (const includePath of config.includePaths) {
+          if (typeof includePath !== 'string') {
+            nonStringIncludePathCount += 1;
+            continue;
+          }
+          includePathEntryCount += 1;
+          incrementCount(includePathKindCounts, classifyLaunchPath(includePath));
+        }
+      }
+    }
+  }
+
+  return {
+    status: 'client_launch_config_reported',
+    configuration_count: configurationCount,
+    perl_configuration_count: perlConfigurationCount,
+    launch_request_count: launchRequestCount,
+    attach_request_count: attachRequestCount,
+    perl_path_configured_count: perlPathConfiguredCount,
+    include_paths_configured_count: includePathsConfiguredCount,
+    include_path_entry_count: includePathEntryCount,
+    non_string_include_path_count: nonStringIncludePathCount,
+    program_configured_count: programConfiguredCount,
+    cwd_configured_count: cwdConfiguredCount,
+    include_path_kind_counts: includePathKindCounts,
+    perl_path_kind_counts: perlPathKindCounts,
+    program_path_kind_counts: programPathKindCounts,
+    cwd_path_kind_counts: cwdPathKindCounts,
+    claim_boundary:
+      'Launch configuration state is summarized from VS Code configuration only. It reports counts and path classes, not raw paths, and does not start DAP, resolve Perl, probe modules, or change debug behavior.',
+  };
+}
+
+export function workspaceTrustClientRuntimeState(
+  context?: vscode.ExtensionContext,
+): Record<string, unknown> {
+  const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
+  const managedDapPath = context ? BinaryDownloader.getLocalDapPath(context) : undefined;
+  const managedAdapterExists = managedDapPath ? fs.existsSync(managedDapPath) : false;
+  const launchJsonWorkspaceCount = workspaceFolders.filter((folder) =>
+    hasLaunchJson(folder.uri.fsPath),
+  ).length;
+  const activeDebugSession = vscode.debug.activeDebugSession;
+  const topology = describeWorkspaceTopology({
+    folders: workspaceFolders,
+    documents: vscode.workspace.textDocuments,
+    isTrusted: vscode.workspace.isTrusted,
+    remoteName: vscode.env.remoteName,
+  });
+
+  return {
+    schema_version: 'workspace_trust_client_runtime.v1',
+    source: 'vscode-extension',
+    perldoc: {
+      status: 'client_surface_registered',
+      uri_scheme: 'perldoc',
+      client_surface: 'perldoc virtual documents are served by the LSP textDocumentContent path',
+    },
+    dap: {
+      status: 'client_state_reported',
+      adapter_registered: true,
+      active_perl_debug_session: activeDebugSession?.type === 'perl',
+      managed_adapter_exists: managedAdapterExists,
+      launch_json_workspace_count: launchJsonWorkspaceCount,
+      workspace_folder_count: workspaceFolders.length,
+      launch_configuration: collectLaunchConfigurationState(workspaceFolders),
+    },
+    topology,
+    claim_boundary:
+      'VS Code client runtime state reads extension/debugger state only. It does not start DAP, run perldoc, probe Perl, or change provider behavior.',
+  };
+}


### PR DESCRIPTION
Problem: Synchronize the tested perl-lsp-swarm VS Code modernization cut into perl-lsp while preserving both repository histories. Fix: This branch is a complete-tree two-parent merge from swarm cut f6b7b2c6626fbefbf01c9c9934cac5789186f8b2, with target-owned .claude and documented swarm-only scripts excluded; it includes swarm PRs #4384, #4389, and #4392. Verification: target cargo check --workspace --locked; npm doctor Node 26.5.0/npm 11.18.0; npm ci; fmt; lint; typecheck:all; compile; test:ci 797 passed and 1 documented skip; package inventory 28 files/1,474,277 bytes; source-map check; exact-source workspace capability smoke passed for trusted multi-root and untrusted hosts. Sync merge commit 9fab4c6703efb5ed7691aca670263a1827741b4c has exactly two parents. Do not squash this PR; normal merge preserves the sync merge and swarm ancestry. No publishing, tagging, or release operation is included.