### PR TITLE
fix(completion): preserve receiver in method edits (#10006)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -776,7 +776,12 @@ impl CompletionProvider {
                 })
                 .map(|p| next_char_boundary_after(source, p))
                 .unwrap_or(0);
-            (source[word_start..position].to_string(), word_start)
+            if word_start >= 2 && source[..word_start].ends_with("->") {
+                let receiver_start = method_receiver_start(source, word_start.saturating_sub(2));
+                (source[receiver_start..position].to_string(), receiver_start)
+            } else {
+                (source[word_start..position].to_string(), word_start)
+            }
         };
 
         // Detect trigger character (trigger chars are ASCII, so byte access is safe)

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/context.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/context.rs
@@ -28,6 +28,20 @@ pub struct CompletionContext {
 }
 
 impl CompletionContext {
+    /// Return the start of the method token for an arrow-form completion.
+    ///
+    /// Arrow receivers remain part of `prefix` for receiver classification, but
+    /// completion edits replace only the method token after `->`.
+    pub(crate) fn method_text_edit_start(&self, source: &str) -> usize {
+        if source.get(self.prefix_start..self.position) == Some(self.prefix.as_str())
+            && let Some(arrow_start) = self.prefix.rfind("->")
+        {
+            return self.prefix_start + arrow_start + 2;
+        }
+
+        self.prefix_start
+    }
+
     pub(crate) fn detect_current_package(symbol_table: &SymbolTable, position: usize) -> String {
         // First, check for innermost package scope containing the position
         let mut scope_start: Option<usize> = None;

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/methods.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/methods.rs
@@ -386,7 +386,7 @@ pub fn add_method_completions(
                 sort_text: Some(format!("1_{}", name)),
                 filter_text: Some(name.clone()),
                 additional_edits: vec![],
-                text_edit_range: Some((context.prefix_start, context.position)),
+                text_edit_range: Some((context.method_text_edit_start(source), context.position)),
                 commit_characters: None,
                 label_details: None,
             });
@@ -443,7 +443,7 @@ pub fn add_method_completions(
                 sort_text: Some(format!("2_{}", method)),
                 filter_text: Some(method.to_string()),
                 additional_edits,
-                text_edit_range: Some((context.prefix_start, context.position)),
+                text_edit_range: Some((context.method_text_edit_start(source), context.position)),
                 commit_characters: None,
                 label_details: None,
             });
@@ -468,7 +468,10 @@ pub fn add_method_completions(
                     sort_text: Some(format!("9_{}", method)), // Lower priority
                     filter_text: Some(method.to_string()),
                     additional_edits,
-                    text_edit_range: Some((context.prefix_start, context.position)),
+                    text_edit_range: Some((
+                        context.method_text_edit_start(source),
+                        context.position,
+                    )),
                     commit_characters: None,
                     label_details: None,
                 });

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/request/dispatch.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/request/dispatch.rs
@@ -128,9 +128,7 @@ fn complete_use_or_structural_context(
 }
 
 fn is_method_arrow_context(context: &CompletionContext) -> bool {
-    (context.trigger_character == Some('>') || context.trigger_character == Some('-'))
-        && context.prefix.ends_with("->")
-        && context.prefix.len() > 2
+    context.prefix.contains("->") && context.prefix.len() > 2
 }
 
 /// Statement-level keywords and I/O builtins that look like a bareword method

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -1626,10 +1626,11 @@ pub fn add_workspace_method_completions(
     // Build an auto-import edit once for all methods from this package.
     let auto_import_edit = auto_import::build_auto_import_edit(source, &package_name);
     let method_symbols = workspace_method_symbols(&members, &existing_labels, method_prefix);
+    let method_text_edit_range = (context.method_text_edit_start(source), context.position);
 
     if add_semantic_method_completions(
         completions,
-        context,
+        method_text_edit_range,
         index,
         &package_name,
         method_prefix,
@@ -1672,7 +1673,7 @@ pub fn add_workspace_method_completions(
             sort_text: Some(format!("{method_tier}_{}", symbol.name)), // tier 2=own, 3=inherited, after local (tier 1)
             filter_text: Some(symbol.name.clone()),
             additional_edits,
-            text_edit_range: Some((context.prefix_start, context.position)),
+            text_edit_range: Some((context.method_text_edit_start(source), context.position)),
             commit_characters: None,
             label_details: None,
         });
@@ -1756,7 +1757,7 @@ fn add_unknown_receiver_fallback(
                     Some(defining_pkg),
                     &context.current_package,
                 ),
-                text_edit_range: Some((context.prefix_start, context.position)),
+                text_edit_range: Some((context.method_text_edit_start(source), context.position)),
                 commit_characters: None,
                 label_details: None,
             });
@@ -1779,7 +1780,7 @@ fn workspace_method_symbols<'a>(
 
 fn add_semantic_method_completions(
     completions: &mut Vec<CompletionItem>,
-    context: &CompletionContext,
+    method_text_edit_range: (usize, usize),
     index: &WorkspaceIndex,
     package_name: &str,
     method_prefix: &str,
@@ -1836,7 +1837,7 @@ fn add_semantic_method_completions(
             )),
             filter_text: Some(candidate.display_name.clone()),
             additional_edits,
-            text_edit_range: Some((context.prefix_start, context.position)),
+            text_edit_range: Some(method_text_edit_range),
             commit_characters: None,
             label_details: None,
         });

--- a/crates/perl-lsp-rs/tests/lsp_workspace_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_workspace_completion_tests.rs
@@ -666,6 +666,91 @@ fn test_completion_inherited_method_from_parent() -> Result<(), Box<dyn std::err
     Ok(())
 }
 
+/// Verify that object method completion replaces the typed method prefix without losing the receiver.
+///
+/// CoC.nvim reported inserting `register_command()` after `$object->register` rather than
+/// replacing the typed method prefix. The server-side contract is an LSP `textEdit` whose range
+/// starts after the receiver, so clients do not need to reconstruct that replacement.
+#[test]
+fn test_object_method_completion_replaces_typed_method_prefix()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = start_lsp_server();
+    initialize_lsp(&server);
+
+    let module_uri = "file:///workspace/CompletionObject.pm";
+    send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": module_uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": "package CompletionObject;\nsub new { bless {}, shift }\nsub register_command { }\n1;\n"
+                }
+            }
+        }),
+    );
+    await_open_processing(&server);
+
+    let script_uri = "file:///workspace/object_completion.pl";
+    let source_line = "$object->register";
+    let source =
+        format!("use CompletionObject;\nmy $object = CompletionObject->new();\n{source_line}");
+    send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": script_uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": source
+                }
+            }
+        }),
+    );
+    await_open_processing(&server);
+
+    let response = send_request(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/completion",
+            "params": {
+                "textDocument": { "uri": script_uri },
+                "position": { "line": 2, "character": source_line.len() }
+            }
+        }),
+    );
+
+    let items = completion_items(&response);
+    let item = items
+        .iter()
+        .find(|item| item["label"].as_str() == Some("register_command"))
+        .ok_or_else(|| format!("register_command completion missing: {items:#?}"))?;
+    let text_edit = item.get("textEdit").ok_or("method completion must include textEdit")?;
+    assert_eq!(text_edit["range"]["start"]["line"], 2);
+    assert_eq!(text_edit["range"]["start"]["character"], 9);
+    assert_eq!(text_edit["range"]["end"]["line"], 2);
+    assert_eq!(
+        text_edit["range"]["end"]["character"],
+        source_line.len(),
+        "textEdit must cover the typed method prefix after the receiver"
+    );
+    assert_eq!(text_edit["newText"], "register_command()");
+
+    let mut completed_line = source_line.to_string();
+    completed_line.replace_range(9..source_line.len(), "register_command()");
+    assert_eq!(completed_line, "$object->register_command()");
+
+    Ok(())
+}
+
 /// Test that method completion detail includes medium-confidence receiver labels.
 ///
 /// Integration counterpart for the receiver-evidence detail format covered in


### PR DESCRIPTION
Problem: Typed object method completion could fall through to ordinary symbol completion, and method edit ranges could remove the receiver or append the method incorrectly.

Fix: Route typed `receiver->method` prefixes through method completion and emit a `textEdit` that replaces only the method token after `->`, preserving the receiver.

Verification: `cargo test -p perl-lsp-rs --profile agent --locked --test lsp_workspace_completion_tests test_object_method_completion_replaces_typed_method_prefix`; `cargo test -p perl-lsp-rs-core --profile agent --locked providers::completion::completion::tests::test_arrow_method_completion_still_works_after_indirect_routing`; scoped clippy and formatting checks pass.