### PR TITLE
feat(workspace): detect Carton and Carmel roots (#3553)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/dependency_detection.rs
+++ b/crates/perl-lsp-rs-core/src/config/dependency_detection.rs
@@ -1,0 +1,99 @@
+//! Marker-based Perl dependency-manager include-path detection.
+
+use std::path::Path;
+
+const CARTON_INCLUDE_PATH: &str = "local/lib/perl5";
+const CARMEL_INCLUDE_PATH: &str = "vendor/lib/perl5";
+
+/// Detect include paths produced by Carton and Carmel in a workspace root.
+///
+/// Carton is identified by `cpanfile` plus either `carton.lock` or
+/// `cpanfile.snapshot`. Carmel is identified by `cpanfile` plus an existing
+/// `vendor/lib/perl5` directory. The returned paths are workspace-relative
+/// and ordered with Carton before Carmel when both markers are present.
+#[must_use]
+pub fn detect_dependency_include_paths(workspace_root: &Path) -> Vec<String> {
+    let has_cpanfile = workspace_root.join("cpanfile").is_file();
+    if !has_cpanfile {
+        return Vec::new();
+    }
+
+    let mut paths = Vec::new();
+    let has_carton_lock = workspace_root.join("carton.lock").is_file();
+    let has_cpanfile_snapshot = workspace_root.join("cpanfile.snapshot").is_file();
+    if has_carton_lock || has_cpanfile_snapshot {
+        paths.push(CARTON_INCLUDE_PATH.to_string());
+    }
+
+    if workspace_root.join(CARMEL_INCLUDE_PATH).is_dir() {
+        paths.push(CARMEL_INCLUDE_PATH.to_string());
+    }
+
+    paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detect_dependency_include_paths;
+
+    #[test]
+    fn detects_carton_from_lockfile() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        std::fs::write(workspace.path().join("cpanfile"), "requires 'JSON';\n")?;
+        std::fs::write(workspace.path().join("carton.lock"), "snapshot\n")?;
+
+        assert_eq!(detect_dependency_include_paths(workspace.path()), vec!["local/lib/perl5"]);
+        Ok(())
+    }
+
+    #[test]
+    fn detects_carton_from_cpanfile_snapshot() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        std::fs::write(workspace.path().join("cpanfile"), "requires 'JSON';\n")?;
+        std::fs::write(workspace.path().join("cpanfile.snapshot"), "snapshot\n")?;
+
+        assert_eq!(detect_dependency_include_paths(workspace.path()), vec!["local/lib/perl5"]);
+        Ok(())
+    }
+
+    #[test]
+    fn detects_carmel_from_vendor_root() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        std::fs::write(workspace.path().join("cpanfile"), "requires 'JSON';\n")?;
+        std::fs::create_dir_all(workspace.path().join("vendor/lib/perl5"))?;
+
+        assert_eq!(detect_dependency_include_paths(workspace.path()), vec!["vendor/lib/perl5"]);
+        Ok(())
+    }
+
+    #[test]
+    fn detects_both_managers_in_stable_order() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        std::fs::write(workspace.path().join("cpanfile"), "requires 'JSON';\n")?;
+        std::fs::write(workspace.path().join("carton.lock"), "snapshot\n")?;
+        std::fs::create_dir_all(workspace.path().join("vendor/lib/perl5"))?;
+
+        assert_eq!(
+            detect_dependency_include_paths(workspace.path()),
+            vec!["local/lib/perl5", "vendor/lib/perl5"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn requires_expected_markers() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        std::fs::write(workspace.path().join("carton.lock"), "snapshot\n")?;
+        assert!(detect_dependency_include_paths(workspace.path()).is_empty());
+
+        std::fs::write(workspace.path().join("cpanfile"), "requires 'JSON';\n")?;
+        assert_eq!(detect_dependency_include_paths(workspace.path()), vec!["local/lib/perl5"]);
+
+        std::fs::remove_file(workspace.path().join("carton.lock"))?;
+        assert!(detect_dependency_include_paths(workspace.path()).is_empty());
+
+        std::fs::create_dir_all(workspace.path().join("vendor/lib/perl5"))?;
+        assert_eq!(detect_dependency_include_paths(workspace.path()), vec!["vendor/lib/perl5"]);
+        Ok(())
+    }
+}

--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -15,11 +15,13 @@ use std::process::{Command, Output, Stdio};
 use std::time::{Duration, Instant};
 use std::{fs::File, io::Read};
 
+mod dependency_detection;
 mod metadata_dependencies;
 mod native_build_hints;
 pub mod perl_oracle_env;
 pub mod toolchain_profile;
 
+pub use dependency_detection::detect_dependency_include_paths;
 pub use metadata_dependencies::{
     DeclaredDependency, DeclaredDependencySource, detect_declared_dependencies,
     extract_build_pl_requirements, extract_cpanfile_requirements, extract_dist_ini_requirements,
@@ -764,6 +766,28 @@ impl WorkspaceConfig {
     /// module-resolution include paths.
     pub fn refresh_declared_dependencies(&mut self, workspace_root: &Path) {
         self.declared_dependencies = detect_declared_dependencies(workspace_root);
+    }
+
+    /// Append marker-detected Carton/Carmel roots to module-resolution paths.
+    ///
+    /// Existing configured paths are preserved in order, and equivalent paths
+    /// are not added twice. `PERL5LIB` is merged later by
+    /// [`Self::effective_include_paths`], so its configured precedence remains
+    /// unchanged.
+    pub fn refresh_dependency_include_paths(&mut self, workspace_root: &Path) {
+        for detected in detect_dependency_include_paths(workspace_root) {
+            let Some(normalized_detected) = normalize_include_path(&detected) else {
+                continue;
+            };
+            let already_present = self
+                .include_paths
+                .iter()
+                .filter_map(|path| normalize_include_path(path))
+                .any(|path| path == normalized_detected);
+            if !already_present {
+                self.include_paths.push(detected);
+            }
+        }
     }
 
     /// Update workspace configuration from LSP settings.

--- a/crates/perl-lsp-rs/src/runtime/workspace_folder.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace_folder.rs
@@ -79,6 +79,7 @@ impl WorkspaceFolderState {
     pub fn refresh_workspace_metadata(&mut self) {
         if let Some(path) = self.path.as_deref() {
             self.effective_workspace_config.refresh_declared_dependencies(path);
+            self.effective_workspace_config.refresh_dependency_include_paths(path);
         }
     }
 
@@ -158,5 +159,43 @@ mod tests {
         assert!(!config.include_paths.is_empty());
         assert_eq!(config.resolution_timeout_ms, 50);
         assert!(!config.use_system_inc);
+    }
+
+    #[test]
+    fn refresh_workspace_metadata_adds_carton_include_path()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        std::fs::write(temp.path().join("cpanfile"), "requires 'JSON';\n")?;
+        std::fs::write(temp.path().join("carton.lock"), "snapshot\n")?;
+        let mut folder = WorkspaceFolderState::new("file:///workspace".to_string())
+            .with_path(temp.path().to_path_buf());
+
+        folder.refresh_workspace_metadata();
+
+        assert_eq!(
+            folder.effective_workspace_config.include_paths,
+            vec!["lib", ".", "local/lib/perl5"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn refresh_workspace_metadata_adds_carmel_include_path()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        std::fs::write(temp.path().join("cpanfile"), "requires 'JSON';\n")?;
+        std::fs::create_dir_all(temp.path().join("vendor/lib/perl5"))?;
+        let mut folder = WorkspaceFolderState::new("file:///workspace".to_string())
+            .with_path(temp.path().to_path_buf());
+
+        folder.refresh_workspace_metadata();
+
+        assert!(
+            folder
+                .effective_workspace_config
+                .include_paths
+                .contains(&"vendor/lib/perl5".to_string())
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
Problem: Workspace resolution does not automatically include dependency roots produced by Carton or Carmel.

Fix: Add a focused marker-based slice: cpanfile plus carton.lock/cpanfile.snapshot detects local/lib/perl5, while cpanfile plus vendor/lib/perl5 detects vendor/lib/perl5. Detected roots are appended without duplicating configured paths and continue through the existing PERL5LIB precedence flow.

Verification: `cargo test -p perl-lsp-rs-core --lib --profile agent --locked config::tests::` (59 passed); `cargo test -p perl-lsp-rs --lib --profile agent --locked runtime::workspace_folder::tests::` (10 passed); scoped clippy, formatting, diff, and storage checks pass.

This is the first reviewable slice for #3553. Lockfile parsing, PERL_CARTON_PATH, wrapper commands, and broader documentation remain follow-up work for the open issue.