### PR TITLE
ci(badge-endpoints): tolerate Actions PR-creation permission denial (#0000)

### DIFF
--- a/.github/workflows/badge-endpoints.yml
+++ b/.github/workflows/badge-endpoints.yml
@@ -89,15 +89,11 @@ jobs:
           git push origin --delete automation/badge-endpoints || echo "automation/badge-endpoints did not exist remotely (or delete failed); continuing -- create-pull-request will create it fresh if needed"
 
       - name: Open badge refresh PR
-        id: cpr
-        # The repository's Actions settings may disallow the default
-        # GITHUB_TOKEN from opening pull requests ("GitHub Actions is not
-        # permitted to create or approve pull requests"). Badge regeneration
-        # above is the payload that must keep failing loudly; opening the PR
-        # is best-effort delivery, so tolerate that permission denial here and
-        # surface it as a ::notice:: in the next step instead of turning the
-        # whole run red.
-        continue-on-error: true
+        # Opt in only after the repository Actions setting allows the
+        # GITHUB_TOKEN to create pull requests. With the variable absent, the
+        # generated badges remain the successful payload and the PR step is
+        # reported as an intentional manual follow-up below.
+        if: vars.BADGE_ENDPOINTS_AUTO_PR == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           branch: automation/badge-endpoints
@@ -113,12 +109,12 @@ jobs:
             cargo xtask badges
             ```
 
-      - name: Report badge PR creation failure
-        if: steps.cpr.outcome == 'failure'
+      - name: Report badge PR creation disabled
+        if: vars.BADGE_ENDPOINTS_AUTO_PR != 'true'
         shell: bash
         run: |
           {
-            echo "::notice title=Badge PR skipped::The badge refresh PR could not be opened."
-            echo "::notice::Likely cause: repository Actions settings disallow the GITHUB_TOKEN from creating pull requests ('GitHub Actions is not permitted to create or approve pull requests')."
-            echo "::notice::Badges were still regenerated successfully in this run. To restore automated badge PRs, a maintainer can enable 'Allow GitHub Actions to create and approve pull requests' under Settings > Actions > General, or open the PR manually from the badges/ diff."
+            echo "::notice title=Badge PR skipped::Automatic badge PR creation is disabled."
+            echo "::notice::Badges were regenerated successfully. To restore automated badge PRs, set repository variable BADGE_ENDPOINTS_AUTO_PR=true after enabling 'Allow GitHub Actions to create and approve pull requests' under Settings > Actions > General."
+            echo "::notice::A maintainer can also open the PR manually from the badges/ diff."
           }

--- a/.github/workflows/badge-endpoints.yml
+++ b/.github/workflows/badge-endpoints.yml
@@ -89,6 +89,15 @@ jobs:
           git push origin --delete automation/badge-endpoints || echo "automation/badge-endpoints did not exist remotely (or delete failed); continuing -- create-pull-request will create it fresh if needed"
 
       - name: Open badge refresh PR
+        id: cpr
+        # The repository's Actions settings may disallow the default
+        # GITHUB_TOKEN from opening pull requests ("GitHub Actions is not
+        # permitted to create or approve pull requests"). Badge regeneration
+        # above is the payload that must keep failing loudly; opening the PR
+        # is best-effort delivery, so tolerate that permission denial here and
+        # surface it as a ::notice:: in the next step instead of turning the
+        # whole run red.
+        continue-on-error: true
         uses: peter-evans/create-pull-request@v8
         with:
           branch: automation/badge-endpoints
@@ -103,3 +112,13 @@ jobs:
             ```bash
             cargo xtask badges
             ```
+
+      - name: Report badge PR creation failure
+        if: steps.cpr.outcome == 'failure'
+        shell: bash
+        run: |
+          {
+            echo "::notice title=Badge PR skipped::The badge refresh PR could not be opened."
+            echo "::notice::Likely cause: repository Actions settings disallow the GITHUB_TOKEN from creating pull requests ('GitHub Actions is not permitted to create or approve pull requests')."
+            echo "::notice::Badges were still regenerated successfully in this run. To restore automated badge PRs, a maintainer can enable 'Allow GitHub Actions to create and approve pull requests' under Settings > Actions > General, or open the PR manually from the badges/ diff."
+          }


### PR DESCRIPTION
Problem: The 'Badge Endpoints' workflow fails on master because the repo Actions settings disallow the default GITHUB_TOKEN from opening PRs — peter-evans/create-pull-request@v8 exits with 'GitHub Actions is not permitted to create or approve pull requests', turning the run red.

Fix: Give that step an id (`cpr`) and `continue-on-error: true` so the permission denial no longer fails the job, and add a follow-up step (`if: steps.cpr.outcome == 'failure'`) that emits ::notice:: annotations explaining the badge PR was skipped and how to re-enable it. Badge regeneration, drift cleanup, and branch-reset steps are untouched and still fail loudly on genuine errors. Workflow-only change — no PAT secrets, no repo-settings changes.

Verification: YAML parsed cleanly (python3 yaml); `actionlint v1.7.7` reports no issues on .github/workflows/badge-endpoints.yml; full diff re-read for correctness. `just pr-fast` could not run: the pre-push hook's `nix develop` fails environmentally (flake pins rust 1.95.0, missing from the pinned nixpkgs rust-bin) — unrelated to this YAML-only change, so pushed with `--no-verify` per the hook's documented bypass policy for environmental failures.

Residual manual step: a maintainer may still want to enable 'Allow GitHub Actions to create and approve pull requests' under Settings > Actions > General to restore automated badge PRs; until then badge diffs are regenerated but the PR is skipped with a ::notice::.