### PR TITLE
fix(quality): require issue references on ignored tests (#4912)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -325,6 +325,23 @@ gates:
     planning:
       role: always_on
 
+  - name: ignored_tests_check_refs
+    tier: pr_fast
+    description: "Require every ignored test to cite a numeric tracking issue"
+    required: true
+    command: just ignored-tests-check-refs
+    timeout_seconds: 180
+    retry_count: 0
+    budgets:
+      max_duration_ms: 120000
+    quarantine: false
+    tags:
+      - hygiene
+      - tests
+      - issue-tracking
+    planning:
+      role: always_on
+
   - name: check_conflict_markers
     tier: pr_fast
     description: "Prevent committed merge conflict markers"
@@ -1519,6 +1536,7 @@ workflow_integration:
     ci-gate:
       gates:
         - fmt
+        - ignored_tests_check_refs
         - clippy_full
         - unit_foundation_full
         - unit_analysis_full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,24 +197,30 @@ jobs:
           shared-key: ci-gate-${{ hashFiles('Cargo.lock') }}
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
 
+      - name: Select PR Smoke Cargo target
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -d /mnt ] && sudo mkdir -p /mnt/perl-lsp-swarm && sudo chown "$USER" /mnt/perl-lsp-swarm; then
+            target_dir="/mnt/perl-lsp-swarm/pr-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
+          else
+            target_dir="${RUNNER_TEMP:-$PWD/target}/cargo-target/pr-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
+          fi
+          mkdir -p "$target_dir"
+          echo "CARGO_TARGET_DIR=$target_dir" >> "$GITHUB_ENV"
+          echo "PR-fast CARGO_TARGET_DIR=$target_dir"
+          df -h . "$target_dir" || true
+
       - name: Warm xtask
         run: cargo build -p xtask --locked
 
       - name: Run PR-fast via shared xtask gate runner
         run: |
           set +e
-          # Keep the heavy Cargo test artifacts out of the checkout filesystem.
+          # The target directory is selected before Warm xtask so gate commands reuse that build.
           # Gate receipts intentionally stay at target/receipts for upload steps.
-          if [ -d /mnt ] && sudo mkdir -p /mnt/perl-lsp-swarm && sudo chown "$USER" /mnt/perl-lsp-swarm; then
-            export CARGO_TARGET_DIR="/mnt/perl-lsp-swarm/pr-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
-          else
-            export CARGO_TARGET_DIR="${RUNNER_TEMP:-$PWD/target}/cargo-target/pr-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
-          fi
-          mkdir -p "$CARGO_TARGET_DIR"
-          echo "PR-fast CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
-          df -h . "$CARGO_TARGET_DIR" || true
           echo "PR-fast timeout policy: GitHub job 50m, outer runner watchdog 45m, per-gate timeouts recorded in target/receipts/receipt.json"
-          timeout --signal=TERM --kill-after=60s 2700s ./target/debug/xtask gates --tier pr-fast --base origin/main --receipt
+          timeout --signal=TERM --kill-after=60s 2700s "$CARGO_TARGET_DIR/debug/xtask" gates --tier pr-fast --base origin/main --receipt
           status=$?
           case "$status" in
             124)
@@ -274,7 +280,7 @@ jobs:
       matrix:
         include:
           - name: meta
-            gates: fmt check_conflict_markers release_history readme_heading_check publish_closure publish_manifest_check layer_check published_crate_count_pr_fast release_history_check perl_token_leaf_contract compile_all_targets clippy_full
+            gates: fmt ignored_tests_check_refs check_conflict_markers release_history readme_heading_check publish_closure publish_manifest_check layer_check published_crate_count_pr_fast release_history_check perl_token_leaf_contract compile_all_targets clippy_full
           - name: foundation
             gates: unit_foundation_full
           - name: analysis

--- a/crates/perl-ci-hygiene/src/lib.rs
+++ b/crates/perl-ci-hygiene/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![warn(missing_docs)]
 
+use regex::Regex;
 use std::fs;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
@@ -69,6 +70,40 @@ pub fn walk_rs_files(root: &Path) -> Vec<PathBuf> {
             }
         })
         .collect()
+}
+
+/// Extract the reason from an `#[ignore]` attribute, including split-line
+/// quoted attributes.
+pub fn extract_ignore_reason(lines: &[String], index: usize, ignore_attr_re: &Regex) -> String {
+    let Some(line) = lines.get(index) else {
+        return String::new();
+    };
+
+    let mut attribute = line.clone();
+    let split_quoted_attribute = attribute.contains("#[ignore")
+        && attribute.contains('=')
+        && !attribute.contains(']')
+        && !attribute.contains('"')
+        && !attribute.contains('\'');
+    let quoted_attribute = attribute.contains("#[ignore = \"")
+        || attribute.contains("#[ignore=\"")
+        || attribute.contains("#[ignore = '")
+        || attribute.contains("#[ignore='")
+        || split_quoted_attribute;
+    if quoted_attribute && !attribute.contains("\"]") && !attribute.contains("']") {
+        for continuation in lines.iter().skip(index + 1).take(8) {
+            attribute.push('\n');
+            attribute.push_str(continuation);
+            if continuation.contains("\"]") || continuation.contains("']") {
+                break;
+            }
+        }
+    }
+
+    ignore_attr_re
+        .captures(&attribute)
+        .and_then(|caps| caps.name("d").or_else(|| caps.name("s")))
+        .map_or_else(String::new, |matched| matched.as_str().to_string())
 }
 
 /// Collect the `Cargo.toml` plus every Rust source file shipped by this crate,
@@ -240,10 +275,22 @@ pub fn categorize_ignore(reason: &str, context: &str) -> String {
 mod tests {
     use super::{categorize_ignore, source_paths};
     use crate::version_sync::{is_pre_release, validate_version_format};
+    use regex::Regex;
     use std::error::Error;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn extract_ignore_reason_handles_split_multiline_attributes() -> Result<(), regex::Error> {
+        let lines = vec!["#[ignore =".to_string(), "    \"tracking #123\"]".to_string()];
+        let regex = Regex::new(
+            r#"^\s*#\[ignore\b(?:(?:\s*=\s*)?\"(?P<d>[^\"]+)\"|\s*=\s*'(?P<s>[^']+)')?"#,
+        )?;
+
+        assert_eq!(super::extract_ignore_reason(&lines, 0, &regex), "tracking #123");
+        Ok(())
+    }
 
     fn unique_temp_repo_dir(label: &str) -> Result<PathBuf, Box<dyn Error>> {
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -5,9 +5,9 @@
 // CLI binary: println!/eprintln! are intentional user-facing output.
 #![allow(clippy::print_stderr, clippy::print_stdout)]
 
-use perl_ci_hygiene::categorize_ignore;
 use perl_ci_hygiene::version_sync;
 use perl_ci_hygiene::walk_rs_files;
+use perl_ci_hygiene::{categorize_ignore, extract_ignore_reason};
 
 use chrono::Utc;
 use clap::Parser;
@@ -2883,14 +2883,7 @@ fn collect_ignored_matches(crates_root: &Path, repo_root: &Path) -> Result<Vec<I
                 continue;
             }
 
-            let mut reason = String::new();
-            if let Some(caps) = ignore_attr_re.captures(line) {
-                if let Some(matched) = caps.name("d") {
-                    reason = matched.as_str().to_string();
-                } else if let Some(matched) = caps.name("s") {
-                    reason = matched.as_str().to_string();
-                }
-            }
+            let mut reason = extract_ignore_reason(&lines, i, &ignore_attr_re);
             let context_lines = {
                 let end = std::cmp::min(lines.len(), i + 4);
                 lines[i..end].join("\n")

--- a/crates/perl-diagnostics/tests/integration_api.rs
+++ b/crates/perl-diagnostics/tests/integration_api.rs
@@ -240,7 +240,7 @@ fn test_tag_lsp_values() {
 
 // Test 19: Workspace count verification (edge case: structural integrity)
 #[test]
-#[ignore] // This test requires external verification (workspace inspection)
+#[ignore = "This test requires external verification (workspace inspection); tracking #4912"]
 fn test_workspace_member_count_should_be_121() {
     // After Wave E: 123 - 3 (removed) + 1 (added) = 121
     // This test documents the expected final count
@@ -252,7 +252,7 @@ fn test_workspace_member_count_should_be_121() {
 
 // Test 20: Publish allowlist count verification (edge case: structural integrity)
 #[test]
-#[ignore] // This test requires external verification (Cargo.toml inspection)
+#[ignore = "This test requires external verification (Cargo.toml inspection); tracking #4912"]
 fn test_publish_allowlist_count_should_be_118() {
     // After Wave E: 120 - 3 (removed) + 1 (added) = 118
     // This test documents the expected final count
@@ -295,7 +295,7 @@ fn test_diagnostic_struct_fields_accessible() {
 
 // Test 23: Layer constraint verification (edge case: architectural integrity)
 #[test]
-#[ignore] // This test requires external verification (xtask layer-check)
+#[ignore = "This test requires external verification (xtask layer-check); tracking #4912"]
 fn test_perl_diagnostics_no_perl_lsp_dependencies() {
     // perl-diagnostics must NOT depend on any perl-lsp-* crate
     // This is enforced by xtask layer-check rule

--- a/crates/perl-lsp-rs-core/tests/g3_publish_baseline_enforcement.rs
+++ b/crates/perl-lsp-rs-core/tests/g3_publish_baseline_enforcement.rs
@@ -48,7 +48,7 @@ fn g3_baseline_file_matches_allowlist() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[test]
-#[ignore] // This test requires cargo metadata to be run in-process; skip in CI if slow
+#[ignore = "This test requires cargo metadata to be run in-process; skip in CI if slow; tracking #4912"]
 fn g3_baseline_matches_cargo_metadata() -> Result<(), Box<dyn std::error::Error>> {
     let root = workspace_root();
 

--- a/crates/perl-lsp-rs/tests/real_project_latency.rs
+++ b/crates/perl-lsp-rs/tests/real_project_latency.rs
@@ -931,7 +931,7 @@ fn test_real_project_resource_inventory_receipt() -> Result<(), Box<dyn std::err
 }
 
 #[test]
-#[ignore = "real-workspace memory lane - starts LSP and records best-effort process RSS"]
+#[ignore = "real-workspace memory lane - starts LSP and records best-effort process RSS; tracking #10015"]
 fn real_project_memory_resource_receipt() -> Result<(), Box<dyn std::error::Error>> {
     let fixtures = [&MOJOLICIOUS_FIXTURE, &DANCER2_FIXTURE, &CATALYST_FIXTURE];
     let mut projects = Map::new();
@@ -1054,7 +1054,7 @@ fn real_project_memory_resource_receipt() -> Result<(), Box<dyn std::error::Erro
 /// cargo test -p perl-lsp-rs --test real_project_latency mojolicious -- --include-ignored --nocapture
 /// ```
 #[test]
-#[ignore = "nightly only — requires fixtures and extended runtime"]
+#[ignore = "nightly only — requires fixtures and extended runtime; tracking #10015"]
 fn real_project_latency_mojolicious() {
     let metrics = measure_project(&MOJOLICIOUS_FIXTURE);
     print_metrics(&metrics);
@@ -1068,7 +1068,7 @@ fn real_project_latency_mojolicious() {
 /// cargo test -p perl-lsp-rs --test real_project_latency dancer2 -- --include-ignored --nocapture
 /// ```
 #[test]
-#[ignore = "nightly only — requires fixtures and extended runtime"]
+#[ignore = "nightly only — requires fixtures and extended runtime; tracking #10015"]
 fn real_project_latency_dancer2() {
     let metrics = measure_project(&DANCER2_FIXTURE);
     print_metrics(&metrics);
@@ -1082,7 +1082,7 @@ fn real_project_latency_dancer2() {
 /// cargo test -p perl-lsp-rs --test real_project_latency catalyst -- --include-ignored --nocapture
 /// ```
 #[test]
-#[ignore = "nightly only — requires fixtures and extended runtime"]
+#[ignore = "nightly only — requires fixtures and extended runtime; tracking #10015"]
 fn real_project_latency_catalyst() {
     let metrics = measure_project(&CATALYST_FIXTURE);
     print_metrics(&metrics);
@@ -1096,7 +1096,7 @@ fn real_project_latency_catalyst() {
 /// cargo test -p perl-lsp-rs --test real_project_latency full_suite -- --include-ignored --nocapture
 /// ```
 #[test]
-#[ignore = "nightly only — requires fixtures and extended runtime"]
+#[ignore = "nightly only — requires fixtures and extended runtime; tracking #10015"]
 fn real_project_latency_full_suite() {
     let fixtures = [&MOJOLICIOUS_FIXTURE, &DANCER2_FIXTURE, &CATALYST_FIXTURE];
     let mut results = Vec::new();
@@ -1117,7 +1117,7 @@ fn real_project_latency_full_suite() {
 /// cargo test -p perl-lsp-rs --test real_project_latency first_diagnostics_5000_line_catalyst -- --include-ignored --nocapture
 /// ```
 #[test]
-#[ignore = "nightly/perf lane — synthetic 5k-line fixture and wall-clock budget"]
+#[ignore = "nightly/perf lane — synthetic 5k-line fixture and wall-clock budget; tracking #10015"]
 fn first_diagnostics_5000_line_catalyst() -> Result<(), Box<dyn std::error::Error>> {
     let app = synthetic_catalyst_app(5000);
     let lines = app.lines().count();

--- a/crates/perl-parser-comparison/tests/corpus_differential.rs
+++ b/crates/perl-parser-comparison/tests/corpus_differential.rs
@@ -101,7 +101,7 @@ fn full_corpus_roots() -> Vec<PathBuf> {
 ///
 /// Produces a human-readable report on stdout when run with `--nocapture`.
 #[test]
-#[ignore]
+#[ignore = "manual full-corpus differential lane; tracking #10015"]
 fn corpus_differential_full() {
     let roots = full_corpus_roots();
     assert!(!roots.is_empty(), "No corpus roots found - is the workspace root reachable?");

--- a/crates/perl-workspace/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace/src/workspace/workspace_index.rs
@@ -8748,7 +8748,7 @@ helper_one();
     }
 
     #[test]
-    #[ignore = "qw delimiter with leading space not yet parsed; tracked in debt-ledger.yaml"]
+    #[ignore = "qw delimiter with leading space not yet parsed; tracking #10013"]
     fn test_index_use_constant_qw_with_space_before_delimiter() {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///workspace/lib/My/Config.pm"));

--- a/justfile
+++ b/justfile
@@ -1673,6 +1673,10 @@ ignored-tests-verbose:
 ignored-tests-update:
     cargo xtask ignored-tests --update
 
+# Fail when any ignored test lacks a numeric issue reference
+ignored-tests-check-refs:
+    cargo --locked xtask ignored-tests --check-issue-refs
+
 # ============================================================================
 # Milestone Verification
 # ============================================================================

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1564,6 +1564,9 @@ enum Commands {
         /// CI gate mode: fail when ignored count increases
         #[arg(long)]
         check: bool,
+        /// Fail when an ignored test lacks a numeric issue reference
+        #[arg(long)]
+        check_issue_refs: bool,
         /// Print detailed per-category breakdown
         #[arg(long, short)]
         verbose: bool,
@@ -4177,8 +4180,8 @@ fn run_cli(cli: Cli) -> Result<()> {
                 queue_reconciler::reconcile_queue(do_apply, pr, receipt)
             }
         },
-        Commands::IgnoredTests { update, check, verbose } => {
-            ignored_tests::run(update, check, verbose)
+        Commands::IgnoredTests { update, check, check_issue_refs, verbose } => {
+            ignored_tests::run(update, check, check_issue_refs, verbose)
         }
         Commands::DebtReport { check, json, summary, expired, ledger } => {
             debt_report::run(debt_report::DebtReportConfig {

--- a/xtask/src/tasks/ignored_tests.rs
+++ b/xtask/src/tasks/ignored_tests.rs
@@ -13,7 +13,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use regex::Regex;
 use walkdir::WalkDir;
 
-use perl_ci_hygiene::categorize_ignore;
+use perl_ci_hygiene::{categorize_ignore, extract_ignore_reason};
 
 use crate::utils::project_root;
 
@@ -50,9 +50,14 @@ pub fn compute_category_counts(root: &Path) -> Result<HashMap<String, usize>> {
     Ok(counts)
 }
 
-pub fn run(update: bool, check: bool, verbose: bool) -> Result<()> {
-    if update && check {
-        return Err(eyre!("choose exactly one of --update or --check for ignored-tests"));
+pub fn run(update: bool, check: bool, check_issue_refs: bool, verbose: bool) -> Result<()> {
+    if update && (check || check_issue_refs) {
+        return Err(eyre!(
+            "--update cannot be combined with --check or --check-issue-refs for ignored-tests"
+        ));
+    }
+    if check && check_issue_refs {
+        return Err(eyre!("choose exactly one of --check or --check-issue-refs for ignored-tests"));
     }
 
     let root = project_root()?;
@@ -72,6 +77,7 @@ pub fn run(update: bool, check: bool, verbose: bool) -> Result<()> {
         records.push(IgnoredDetail {
             category,
             location: detail.location,
+            context: detail.context,
             test_name: detail.test_name,
             reason: detail.reason,
         });
@@ -161,7 +167,27 @@ pub fn run(update: bool, check: bool, verbose: bool) -> Result<()> {
 
     // ── Mode dispatch ───────────────────────────────────────────────────
 
-    if update {
+    if check_issue_refs {
+        let missing_refs: Vec<&IgnoredDetail> = records
+            .iter()
+            .filter(|record| {
+                !has_issue_reference(&record.reason) && !has_issue_reference(&record.context)
+            })
+            .collect();
+        if missing_refs.is_empty() {
+            println!("{GREEN}OK: every ignored test cites an issue reference{NC}");
+        } else {
+            let missing_count = missing_refs.len();
+            println!("{RED}ERROR: ignored tests missing issue references:{NC}");
+            for record in missing_refs {
+                println!("  {}", record.location);
+                if !record.test_name.is_empty() {
+                    println!("    fn: {}", record.test_name);
+                }
+            }
+            return Err(eyre!("{missing_count} ignored tests lack issue references"));
+        }
+    } else if update {
         write_ignored_baseline(&baseline_path, &counts, total)?;
         println!("{GREEN}Baseline updated successfully.{NC}");
     } else if check {
@@ -263,6 +289,7 @@ struct IgnoreMatch {
 struct IgnoredDetail {
     category: String,
     location: String,
+    context: String,
     reason: String,
     test_name: String,
 }
@@ -300,14 +327,7 @@ fn collect_ignored_matches(crates_root: &Path, repo_root: &Path) -> Result<Vec<I
                 continue;
             }
 
-            let mut reason = String::new();
-            if let Some(caps) = ignore_attr_re.captures(line) {
-                if let Some(matched) = caps.name("d") {
-                    reason = matched.as_str().to_string();
-                } else if let Some(matched) = caps.name("s") {
-                    reason = matched.as_str().to_string();
-                }
-            }
+            let mut reason = extract_ignore_reason(&lines, i, &ignore_attr_re);
 
             let context_lines = {
                 let end = std::cmp::min(lines.len(), i + 4);
@@ -349,6 +369,14 @@ fn collect_ignored_matches(crates_root: &Path, repo_root: &Path) -> Result<Vec<I
         }
     }
     Ok(results)
+}
+
+fn has_issue_reference(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes
+        .iter()
+        .enumerate()
+        .any(|(index, byte)| *byte == b'#' && bytes.get(index + 1).is_some_and(u8::is_ascii_digit))
 }
 
 // ── Categorisation ──────────────────────────────────────────────────────────
@@ -401,6 +429,27 @@ mod tests {
     #[test]
     fn categorize_other() {
         assert_eq!(categorize_ignore("some unique unmatched reason", ""), "other");
+    }
+
+    #[test]
+    fn issue_reference_detection_requires_digits_after_hash() {
+        assert!(has_issue_reference("tracking #4912"));
+        assert!(!has_issue_reference("tracking #NNNN"));
+        assert!(!has_issue_reference("hash in prose only"));
+    }
+
+    #[test]
+    fn extract_ignore_reason_handles_multiline_attributes() -> Result<()> {
+        let lines = vec![
+            r#"#[ignore = "requires the renamed package; see issue "#.to_string(),
+            r#"            #1226"]"#.to_string(),
+        ];
+        let regex = Regex::new(
+            r#"^\s*#\[ignore\b(?:(?:\s*=\s*)?\"(?P<d>[^\"]+)\"|\s*=\s*'(?P<s>[^']+)')?"#,
+        )?;
+        let reason = extract_ignore_reason(&lines, 0, &regex);
+        assert!(reason.contains("#1226"));
+        Ok(())
     }
 
     #[test]

--- a/xtask/tests/quality_ci_wiring_policy.rs
+++ b/xtask/tests/quality_ci_wiring_policy.rs
@@ -6,6 +6,52 @@ use assert_cmd::Command;
 use perl_tdd_support::{must, must_some};
 
 #[test]
+fn ignored_test_issue_reference_gate_is_required_on_prs() {
+    let root = repo_root();
+    let policy = must(fs::read_to_string(root.join(".ci/gate-policy.yaml")));
+    let gate_start = must_some(policy.find("  - name: ignored_tests_check_refs"));
+    let gate_tail = &policy[gate_start..];
+    let gate_end = gate_tail.find("\n  - name:").unwrap_or(gate_tail.len());
+    let gate = &gate_tail[..gate_end];
+    assert!(
+        gate.contains("tier: pr_fast")
+            && gate.contains("required: true")
+            && gate.contains("command: just ignored-tests-check-refs")
+            && gate.contains("timeout_seconds: 180")
+            && gate.contains("quarantine: false")
+            && gate.contains("role: always_on"),
+        "gate policy must keep the ignored-test issue-reference gate required on the PR fast lane"
+    );
+
+    let workflow = must(fs::read_to_string(root.join(".github/workflows/ci.yml")));
+    let shards_start = must_some(workflow.find("merge-gate-shards:"));
+    let shards = &workflow[shards_start..];
+    let next_job = shards.find("\nmerge-gate:").unwrap_or(shards.len());
+    assert!(
+        shards[..next_job].contains("ignored_tests_check_refs"),
+        "merge-gate-shards must execute the ignored-test issue-reference gate"
+    );
+
+    let smoke_start = must_some(workflow.find("  pr-smoke:"));
+    let smoke = &workflow[smoke_start..];
+    let target_start = must_some(smoke.find("- name: Select PR Smoke Cargo target"));
+    let warm_start = must_some(smoke.find("- name: Warm xtask"));
+    let target_step = must_some(workflow_step(smoke, "Select PR Smoke Cargo target"));
+    assert!(
+        target_start < warm_start,
+        "PR Smoke must select CARGO_TARGET_DIR before warming xtask"
+    );
+    assert!(
+        target_step.contains("CARGO_TARGET_DIR=$target_dir") && target_step.contains("GITHUB_ENV"),
+        "PR Smoke must persist its cargo target for the shared gate runner"
+    );
+    assert!(
+        smoke.contains("\"$CARGO_TARGET_DIR/debug/xtask\" gates --tier pr-fast"),
+        "PR Smoke must invoke the warmed xtask from its selected cargo target"
+    );
+}
+
+#[test]
 fn ripr_workflow_blocks_new_gaps_and_requires_receipts() {
     let root = repo_root();
     let workflow = must(fs::read_to_string(root.join(".github/workflows/ripr.yml")));


### PR DESCRIPTION
Problem: ignored-test metadata and the xtask report did not enforce numeric issue references, and multiline ignore reasons were misclassified as bare.

Fix: add `ignored-tests --check-issue-refs`, share multiline-aware ignore parsing between the native and legacy hygiene reports, attach tracking references to the existing ignored tests, and wire the required gate into CI policy and the merge-gate meta shard.

Verification: Rust 1.95 `cargo fmt --all -- --check`; `perl-ci-hygiene` tests 89/89; targeted `xtask` tests 17/17; clippy passes for both affected packages; native and legacy reports both find 13 ignored tests with 0 bare entries; issue-reference gate passes; storage doctor passes. Hosted CI for head `61420c4c` is pending.