### PR TITLE
fix(lsp): match qualified subroutine implementations (#6751)

### DIFF
--- a/crates/perl-lsp-rs/src/features/implementation_provider.rs
+++ b/crates/perl-lsp-rs/src/features/implementation_provider.rs
@@ -399,13 +399,14 @@ impl ImplementationProvider {
                         // Compare bare names so a qualified declaration such as
                         // `sub Foo::process` matches a lookup for `process`
                         // (issue #6751), mirroring `find_method_in_ast`.
-                        let (_, sub_bare) =
+                        let (sub_package, sub_bare) =
                             perl_parser::qualified_name::split_qualified_name(sub_name);
                         let (_, method_bare) =
                             perl_parser::qualified_name::split_qualified_name(method_name);
-                        if current_package.as_deref() == Some(package_name)
-                            && sub_bare == method_bare
-                        {
+                        let package_matches = sub_package == Some(package_name)
+                            || (sub_package.is_none()
+                                && current_package.as_deref() == Some(package_name));
+                        if package_matches && sub_bare == method_bare {
                             let target_uri = parse_uri(uri);
                             results.push(LocationLink {
                                 origin_selection_range: None,
@@ -653,6 +654,41 @@ mod tests {
             &mut results,
         );
         assert!(results.is_empty(), "sub declared in package Other must not match package Foo");
+        Ok(())
+    }
+
+    /// A qualified declaration belongs to its explicit package, even when it
+    /// appears inside a different enclosing package.
+    #[test]
+    fn find_method_in_package_uses_explicit_qualified_package()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let source = "package Other;\nsub Foo::process { return 1; }\n";
+        let ast = parse(source)?;
+        let provider = ImplementationProvider::new(None);
+        let mut foo_results = Vec::new();
+        provider.find_method_in_package(
+            &ast,
+            "process",
+            "Foo",
+            "file:///test.pl",
+            source,
+            &mut foo_results,
+        );
+        assert_eq!(foo_results.len(), 1, "Foo::process must resolve under Foo");
+
+        let mut other_results = Vec::new();
+        provider.find_method_in_package(
+            &ast,
+            "process",
+            "Other",
+            "file:///test.pl",
+            source,
+            &mut other_results,
+        );
+        assert!(
+            other_results.is_empty(),
+            "Foo::process must not resolve under its enclosing package Other"
+        );
         Ok(())
     }
 }

--- a/crates/perl-lsp-rs/src/features/implementation_provider.rs
+++ b/crates/perl-lsp-rs/src/features/implementation_provider.rs
@@ -396,8 +396,15 @@ impl ImplementationProvider {
                         *current_package = Some(name.clone());
                     }
                     NodeKind::Subroutine { name: Some(sub_name), .. } => {
+                        // Compare bare names so a qualified declaration such as
+                        // `sub Foo::process` matches a lookup for `process`
+                        // (issue #6751), mirroring `find_method_in_ast`.
+                        let (_, sub_bare) =
+                            perl_parser::qualified_name::split_qualified_name(sub_name);
+                        let (_, method_bare) =
+                            perl_parser::qualified_name::split_qualified_name(method_name);
                         if current_package.as_deref() == Some(package_name)
-                            && *sub_name == method_name
+                            && sub_bare == method_bare
                         {
                             let target_uri = parse_uri(uri);
                             results.push(LocationLink {
@@ -570,4 +577,82 @@ enum ImplementationTarget {
     },
     #[allow(dead_code)]
     BlessedType(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(source: &str) -> Result<Node, Box<dyn std::error::Error>> {
+        let mut parser = crate::Parser::new(source);
+        Ok(parser.parse()?)
+    }
+
+    /// Regression test for issue #6751: `find_method_in_package` must match a
+    /// package-qualified declaration (`sub Foo::process`) when looking up the
+    /// bare method name `process`. Before the fix, `*sub_name == method_name`
+    /// compared "Foo::process" to "process" and the implementation was missed.
+    #[test]
+    fn find_method_in_package_matches_qualified_decl_by_bare_name()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let source = "package Foo;\nsub Foo::process { return 1; }\n";
+        let ast = parse(source)?;
+        let provider = ImplementationProvider::new(None);
+        let mut results = Vec::new();
+        provider.find_method_in_package(
+            &ast,
+            "process",
+            "Foo",
+            "file:///test.pl",
+            source,
+            &mut results,
+        );
+        assert_eq!(
+            results.len(),
+            1,
+            "qualified `sub Foo::process` must be found when searching for bare 'process'"
+        );
+        Ok(())
+    }
+
+    /// Boundary discriminator (issue #6751): a declaration whose bare name
+    /// differs from the target must NOT match, even inside the right package.
+    #[test]
+    fn find_method_in_package_rejects_different_bare_name() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let source = "package Foo;\nsub Foo::process { return 1; }\n";
+        let ast = parse(source)?;
+        let provider = ImplementationProvider::new(None);
+        let mut results = Vec::new();
+        provider.find_method_in_package(
+            &ast,
+            "other",
+            "Foo",
+            "file:///test.pl",
+            source,
+            &mut results,
+        );
+        assert!(results.is_empty(), "must not match a different bare name");
+        Ok(())
+    }
+
+    /// Cross-package guard: a declaration inside a *different* package must
+    /// not be reported as an implementation of the target package's method.
+    #[test]
+    fn find_method_in_package_respects_package_scope() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "package Other;\nsub process { return 1; }\n";
+        let ast = parse(source)?;
+        let provider = ImplementationProvider::new(None);
+        let mut results = Vec::new();
+        provider.find_method_in_package(
+            &ast,
+            "process",
+            "Foo",
+            "file:///test.pl",
+            source,
+            &mut results,
+        );
+        assert!(results.is_empty(), "sub declared in package Other must not match package Foo");
+        Ok(())
+    }
 }

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -541,7 +541,7 @@ impl<'a> DeclarationProvider<'a> {
         // If we have a target package, find subs in that specific package
         if let Some(pkg_name) = target_package {
             if let Some(decl) =
-                declarations.iter().find(|d| self.find_current_package(d) == Some(pkg_name))
+                declarations.iter().find(|d| self.declaration_matches_package(d, pkg_name))
             {
                 return Some(vec![self.create_location_link(
                     node,
@@ -549,10 +549,8 @@ impl<'a> DeclarationProvider<'a> {
                     self.get_subroutine_name_range(decl),
                 )]);
             }
-        }
-
-        // Otherwise return the first match
-        if let Some(decl) = declarations.first() {
+        } else if let Some(decl) = declarations.first() {
+            // An unqualified call resolves against the surrounding package.
             return Some(vec![self.create_location_link(
                 node,
                 decl,
@@ -598,7 +596,7 @@ impl<'a> DeclarationProvider<'a> {
             self.collect_subroutine_declarations(&self.ast, method_name, &mut declarations);
 
             if let Some(decl) =
-                declarations.iter().find(|d| self.find_current_package(d) == Some(pkg))
+                declarations.iter().find(|d| self.declaration_matches_package(d, pkg))
             {
                 return Some(vec![self.create_location_link(
                     node,
@@ -841,6 +839,22 @@ impl<'a> DeclarationProvider<'a> {
         }
 
         None
+    }
+
+    /// Return whether a declaration belongs to a requested package.
+    ///
+    /// A qualified subroutine such as `sub Foo::bar` belongs to `Foo` even
+    /// when it appears inside a different enclosing package. Bare
+    /// declarations and other callable nodes continue to use their enclosing
+    /// package context.
+    fn declaration_matches_package(&self, node: &Node, package_name: &str) -> bool {
+        if let NodeKind::Subroutine { name: Some(name), .. } = &node.kind {
+            let (qualifier, _) = split_qualified_name(name);
+            return qualifier == Some(package_name)
+                || (qualifier.is_none() && self.find_current_package(node) == Some(package_name));
+        }
+
+        self.find_current_package(node) == Some(package_name)
     }
 
     /// Create a location link
@@ -2607,6 +2621,23 @@ mod tests {
             subs.is_empty(),
             "collect_subroutine_declarations must NOT collect `sub Foo::bar` when searching for 'baz'; got {count} node(s)",
             count = subs.len()
+        );
+    }
+
+    /// A qualified declaration belongs to its explicit package, even when
+    /// the source is currently inside a different package.
+    #[test]
+    fn qualified_subroutine_resolution_uses_explicit_package() {
+        let source = "package Other;\nsub Foo::bar { return 1; }\n";
+        let provider = make_provider(source);
+
+        assert!(
+            provider.find_subroutine_declaration(&provider.ast, "Foo::bar").is_some(),
+            "qualified Foo::bar must resolve from its explicit package"
+        );
+        assert!(
+            provider.find_subroutine_declaration(&provider.ast, "Other::bar").is_none(),
+            "qualified Foo::bar must not resolve as an Other::bar declaration"
         );
     }
 

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -6,6 +6,7 @@
 use crate::ast::{GotoTargetForm, Node, NodeKind};
 use crate::symbol::is_universal_method;
 use crate::workspace_index::{SymKind, SymbolKey};
+use perl_parser_core::qualified_name::split_qualified_name;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
@@ -879,7 +880,12 @@ impl<'a> DeclarationProvider<'a> {
         subs: &mut Vec<&'b Node>,
     ) {
         match &node.kind {
-            NodeKind::Subroutine { name: Some(name_str), .. } if name_str == sub_name => {
+            // Strip the package qualifier so a qualified declaration like
+            // `sub Foo::bar` matches a bare lookup for `bar` (issue #6751),
+            // mirroring the typeglob arm below.
+            NodeKind::Subroutine { name: Some(name_str), .. }
+                if split_qualified_name(name_str).1 == sub_name =>
+            {
                 subs.push(node);
             }
             // Method declarations (Perl 5.38+ native class / Object::Pad).
@@ -2565,6 +2571,42 @@ mod tests {
             packages.is_empty(),
             "collect_package_declarations must NOT collect Foo when searching for Bar; got {count} node(s)",
             count = packages.len()
+        );
+    }
+
+    /// Regression test for issue #6751: a package-qualified declaration
+    /// (`sub Foo::bar`) stores its name as "Foo::bar"; searching for the bare
+    /// name `bar` must still find it. Before the fix, `name_str == sub_name`
+    /// compared "Foo::bar" to "bar" and the declaration was silently missed.
+    #[test]
+    fn collect_subroutine_declarations_matches_qualified_decl_by_bare_name() {
+        let source = "sub Foo::bar { return 1; }";
+        let provider = make_provider(source);
+        let mut subs = Vec::new();
+        provider.collect_subroutine_declarations(&provider.ast, "bar", &mut subs);
+        assert!(
+            !subs.is_empty(),
+            "collect_subroutine_declarations must find qualified `sub Foo::bar` when searching for bare 'bar'; got empty vec"
+        );
+        assert!(
+            matches!(&subs[0].kind, NodeKind::Subroutine { name: Some(n), .. } if n == "Foo::bar"),
+            "collected declaration must be the Subroutine node named 'Foo::bar'"
+        );
+    }
+
+    /// Boundary discriminator for the qualified-name comparison (issue #6751):
+    /// a declaration whose bare name differs from the target must NOT match,
+    /// even when it carries a package qualifier.
+    #[test]
+    fn collect_subroutine_declarations_rejects_qualified_decl_with_different_bare_name() {
+        let source = "sub Foo::bar { return 1; }";
+        let provider = make_provider(source);
+        let mut subs = Vec::new();
+        provider.collect_subroutine_declarations(&provider.ast, "baz", &mut subs);
+        assert!(
+            subs.is_empty(),
+            "collect_subroutine_declarations must NOT collect `sub Foo::bar` when searching for 'baz'; got {count} node(s)",
+            count = subs.len()
         );
     }
 


### PR DESCRIPTION
## What this does

Qualified Perl declarations such as `sub Foo::process` were missed by semantic declaration lookup and the LSP implementation provider when callers searched for the bare method name.

**Fix:** compare the bare component returned by the shared qualified-name parser while preserving package-scope and non-matching-name guards.

## Verification

| Check | Result |
| --- | --- |
| qualified declaration regressions and negative controls | pass on current `origin/master` transplant |
| `cargo check --all-targets`, `cargo clippy` for both owning crates | pass |
| `just pr-fast` | 15/18 gates pass; three unrelated timing-sensitive suites failed under load, and representative failures pass individually on untouched `origin/master` |

## Review map

- `DeclarationProvider::collect_subroutine_declarations`: matches qualified declarations by bare name.
- `ImplementationProvider::find_method_in_package`: applies the same comparison while retaining package scope.
- Unit tests: cover qualified matches, different-name rejection, and cross-package rejection.

Closes #6751
