### PR TITLE
fix(quality): enable missing docs warnings (#4911)

### DIFF
--- a/crates/perl-ast-v2/src/lib.rs
+++ b/crates/perl-ast-v2/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Enhanced AST with full position tracking for incremental parsing
 //!
 //! This module provides an updated AST that uses Range instead of SourceLocation

--- a/crates/perl-ast/src/lib.rs
+++ b/crates/perl-ast/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Perl AST library -- typed syntax tree for Perl source code.
 //!
 //! This crate defines the Abstract Syntax Tree used by `perl-parser-core` and

--- a/crates/perl-core-harness-types/src/lib.rs
+++ b/crates/perl-core-harness-types/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Shared receipt contracts for the upstream Perl core harness lane.
 
 use clap::ValueEnum;

--- a/crates/perl-core-harness/src/lib.rs
+++ b/crates/perl-core-harness/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Upstream Perl core harness integration scaffold.
 //!
 //! The scaffold can discover tests from a prepared Perl source tree and run the

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Comprehensive Perl test corpus and property-based testing infrastructure
 //!
 //! This crate provides a curated collection of Perl code samples for testing parser correctness,

--- a/crates/perl-dead-code/src/lib.rs
+++ b/crates/perl-dead-code/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Dead code detection for Perl codebases (stub implementation)
 //!
 //! This module identifies unused code including unreachable code and unused symbols.

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! UX regression test harness for perl-lsp.
 //!
 //! Provides a programmatic simulation of common first-5-minutes user experiences.

--- a/crates/perl-module/src/lib.rs
+++ b/crates/perl-module/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Unified Perl module facade.
 //!
 //! This crate absorbs 13 `perl-module-*` microcrates into a single published

--- a/crates/perl-parser-pest/src/lib.rs
+++ b/crates/perl-parser-pest/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Legacy Pest-based Perl parser (v2).
 //!
 //! This crate provides a pure Rust Perl parser built with the Pest parser generator.

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Pragma tracker for Perl code analysis
 //!
 //! Tracks `use` and `no` pragmas throughout the codebase to determine

--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Perl regex validation and analysis.
 
 pub mod analyzer;

--- a/crates/perl-ripr-facts/src/lib.rs
+++ b/crates/perl-ripr-facts/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Batch exporter for the `ripr-perl-facts-v1` packet.
 //!
 //! This crate owns the `ripr-facts` unit that previously lived inside the LSP

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Neutral semantic fact vocabulary for Perl analysis layers.
 //!
 //! This crate defines strongly-typed IDs and serializable fact records that can be shared

--- a/crates/perl-test-generators/src/lib.rs
+++ b/crates/perl-test-generators/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Property-based test generators for Perl domain objects.
 //!
 //! This crate provides reusable [`proptest::Strategy`] implementations for

--- a/crates/perl-test-must/src/lib.rs
+++ b/crates/perl-test-must/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Safe unwrap replacements for tests.
 //!
 //! This crate provides panic-on-failure helpers that are safe to use in tests,

--- a/crates/perllsp/src/lib.rs
+++ b/crates/perllsp/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Public Cargo facade for the `perllsp` language server.
 //!
 //! Install the server with:

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![cfg_attr(clippy, allow(missing_docs))]
+
 //! Tree-sitter Perl grammar binding (C FFI).
 //!
 //! This crate is the conventional C/tree-sitter reference implementation for


### PR DESCRIPTION
Problem: 17 workspace library crates did not participate in the missing-docs quality rollout.

Fix: enable `#![warn(missing_docs)]` at each affected crate root as the Phase 1 documentation lint baseline. Add a clippy-only allowance so strict clippy remains green while normal checks emit the measured warnings; documentation burn-down and facade `deny` promotion remain separate follow-up work.

Verification: Rust 1.95 targeted `cargo check --all-targets --locked` passes with expected missing-doc warnings; strict workspace library clippy passes; workspace bins clippy passes; `cargo fmt --all -- --check`; `git diff --check`; storage doctor passes.