### PR TITLE
test(lsp): prove dependency roots reach providers (#3553)

### DIFF
--- a/crates/perl-lsp-rs/tests/dependency_manager_lsp_tests.rs
+++ b/crates/perl-lsp-rs/tests/dependency_manager_lsp_tests.rs
@@ -1,0 +1,118 @@
+//! Request-level coverage for marker-based dependency-manager include roots.
+
+mod support;
+
+use serde_json::{Value, json};
+use support::lsp_harness::{LspHarness, TempWorkspace};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn labels(result: &Value) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let items = result
+        .as_array()
+        .or_else(|| result.get("items").and_then(Value::as_array))
+        .ok_or_else(|| std::io::Error::other(format!("expected completion list, got {result}")))?;
+    Ok(items
+        .iter()
+        .filter_map(|item| item.get("label").and_then(Value::as_str).map(ToOwned::to_owned))
+        .collect())
+}
+
+fn initialize_with_project_paths(
+    workspace: &TempWorkspace,
+    files: &[(&str, &str)],
+) -> Result<(LspHarness, String), String> {
+    workspace.write(".perl-lsp.toml", "[perl]\ninclude_paths = [\"lib\"]\n")?;
+    for (path, content) in files {
+        workspace.write(path, content)?;
+    }
+
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_ready(&workspace.root_uri, None)?;
+    Ok((harness, workspace.uri("main.pl")))
+}
+
+#[test]
+fn carton_root_reaches_module_completion() -> TestResult {
+    let workspace = TempWorkspace::new()?;
+    let (mut harness, main_uri) = initialize_with_project_paths(
+        &workspace,
+        &[
+            ("cpanfile", "# Carton project marker\n"),
+            ("carton.lock", "snapshot\n"),
+            ("local/lib/perl5/Carton/Only.pm", "package Carton::Only;\n1;\n"),
+        ],
+    )?;
+    let source = "use Carton::O";
+    harness.open(&main_uri, source)?;
+    harness.barrier();
+
+    let result = harness.completion_at(&main_uri, 0, source.len() as u32)?;
+    let labels = labels(&result)?;
+    assert!(
+        labels.iter().any(|label| label == "Carton::Only"),
+        "Carton-detected local module should be offered by completion, got {labels:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn carmel_root_reaches_module_definition() -> TestResult {
+    let workspace = TempWorkspace::new()?;
+    let (mut harness, main_uri) = initialize_with_project_paths(
+        &workspace,
+        &[
+            ("cpanfile", "requires 'Carmel::Only';\n"),
+            ("vendor/lib/perl5/Carmel/Only.pm", "package Carmel::Only;\n1;\n"),
+        ],
+    )?;
+    let source = "use Carmel::Only;\n";
+    harness.open(&main_uri, source)?;
+    harness.barrier();
+
+    let position = source.find("Carmel::Only").ok_or("test source is missing Carmel::Only")? as u32;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 0, "character": position }
+        }),
+    )?;
+    let locations = result
+        .as_array()
+        .ok_or_else(|| std::io::Error::other(format!("expected definition array, got {result}")))?;
+    let expected_uri = workspace.uri("vendor/lib/perl5/Carmel/Only.pm");
+    assert!(
+        locations.iter().any(|location| {
+            location.get("uri").and_then(Value::as_str) == Some(expected_uri.as_str())
+        }),
+        "Carmel-detected vendor module should resolve to {expected_uri}, got {locations:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn carmel_root_does_not_activate_without_cpanfile() -> TestResult {
+    let workspace = TempWorkspace::new()?;
+    let (mut harness, main_uri) = initialize_with_project_paths(
+        &workspace,
+        &[("vendor/lib/perl5/Carmel/Only.pm", "package Carmel::Only;\n1;\n")],
+    )?;
+    let source = "use Carmel::Only;\n";
+    harness.open(&main_uri, source)?;
+    harness.barrier();
+
+    let position = source.find("Carmel::Only").ok_or("test source is missing Carmel::Only")? as u32;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": main_uri },
+            "position": { "line": 0, "character": position }
+        }),
+    )?;
+    assert!(
+        result.as_array().is_some_and(Vec::is_empty),
+        "Carmel vendor path must stay inactive without cpanfile, got {result}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## What this does

Carton/Carmel marker detection was covered at the configuration layer, but the live LSP providers had no proof that those roots reach editor requests. This left the issue's user-visible completion and navigation contract untested.

**Change:** add request-level regressions for Carton module completion and Carmel go-to-definition, plus a negative Carmel marker case. Fixtures override default include paths so the Carton test proves detection contributes the root rather than relying on the built-in default.

## Verification

| Check | Result |
| --- | --- |
| dependency-manager LSP tests | 3 passed |
| Carton/Carmel detector tests | 5 passed |
| `cargo fmt --all`, `git diff --check` | clean |
| `cargo check --all-targets -p perl-lsp-rs` | pass |
| scoped clippy for new integration target | pass |
| `just pr-fast` | 16 gates passed; two unrelated full-suite timeout failures passed individually on clean `origin/master` and this branch |

## Review map

- `crates/perl-lsp-rs/tests/dependency_manager_lsp_tests.rs`: real LSP initialization and provider requests proving Carton completion, Carmel definition, and Carmel marker gating.
- Existing `dependency_detection` unit tests: detector marker semantics and ordering remain covered.