### PR TITLE
docs(vscode): route onboarding health checks through extension (#0000)

### DIFF
--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -4,12 +4,15 @@ This guide gets you from zero to a working Perl language server in your editor.
 
 ## First Success
 
-The fastest validation path is:
+For VS Code, the fastest validation path is:
 
-1. Install `perllsp`
-2. Run `perllsp --health`
-3. Open a Perl file in your editor
+1. Install the `perl-lsp` extension
+2. Open a `.pl` or `.pm` file
+3. Run **Perl: Run Health Check** from the Command Palette
 4. Confirm you get diagnostics and hover text
+
+For other editors or a manually installed server, put `perllsp` on your
+`PATH` and run `perllsp --health` before opening a Perl file.
 
 If those four steps work, your install is good and the rest of this guide is
 just editor-specific setup and feature discovery.
@@ -55,7 +58,7 @@ cd perl-lsp
 cargo install --path crates/perllsp
 ```
 
-## Verify Installation
+## Verify a Manual Installation
 
 ```bash
 # Check binary is available

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1239,7 +1239,7 @@
           {
             "id": "verify-perl",
             "title": "Verify Your Perl Installation",
-            "description": "Run the health check to confirm your Perl interpreter is available (used by the test runner and debugger). Native formatting and native critic diagnostics are built in — perltidy and perlcritic are optional and only used for explicit external-compatibility modes.",
+            "description": "Run [Perl: Run Health Check](command:perl-lsp.runHealthCheck) to confirm your Perl interpreter is available (used by the test runner and debugger). Native formatting and native critic diagnostics are built in — perltidy and perlcritic are optional and only used for explicit external-compatibility modes.",
             "media": {
               "image": "media/walkthrough/verify-perl.svg",
               "altText": "Verify Perl"

--- a/vscode-extension/src/test/walkthrough.test.ts
+++ b/vscode-extension/src/test/walkthrough.test.ts
@@ -142,6 +142,16 @@ describe('package.json walkthrough contribution', () => {
     expect(step.description).not.toMatch(/Perl tooling \(perl, perltidy/i);
   });
 
+  test('verify-perl step exposes the extension health-check command', () => {
+    const wt = findRequired(pkg.contributes.walkthroughs, () => true, 'a walkthrough');
+    const step = findRequired(
+      wt.steps,
+      (s: WalkthroughStep) => s.id === 'verify-perl',
+      'verify-perl step',
+    );
+    expect(step.description).toMatch(/command:perl-lsp\.runHealthCheck/);
+  });
+
   test('open-project step offers the bundled demo project (#1635)', () => {
     const wt = findRequired(pkg.contributes.walkthroughs, () => true, 'a walkthrough');
     const step = findRequired(


### PR DESCRIPTION
## What this does

The VS Code extension manages and downloads `perllsp`, but the first-success guide told VS Code users to install and invoke the standalone CLI health check. That adds an unnecessary PATH/setup hurdle before the editor can be tried.

**Change:** make the VS Code-first path use `Perl: Run Health Check`, keep `perllsp --health` for other editors and manual installs, and add a walkthrough contract test for the command link.

## Verification

| Check | Result |
| --- | --- |
| targeted VS Code Jest suites | 3 passed, 153 tests |
| `npm run typecheck:all` | pass |
| package JSON parse | pass |
| `git diff --check` | clean |

## Review map

- `docs/tutorials/GETTING_STARTED.md`: separates VS Code extension verification from manual server verification.
- `vscode-extension/package.json`: links the walkthrough step to the extension health-check command.
- `vscode-extension/src/test/walkthrough.test.ts`: prevents the command link from drifting.