### PR TITLE
feat(parser): classify parse errors for agent routing (#4926)

### DIFF
--- a/crates/perl-parser-core/src/engine/error/mod.rs
+++ b/crates/perl-parser-core/src/engine/error/mod.rs
@@ -27,7 +27,7 @@ pub mod recovery {
 
 /// Error types and result aliases used by the parser engine.
 pub use crate::syntax::error::{
-    BudgetTracker, ErrorContext, ParseBudget, ParseDiagnosticSeverity, ParseError, ParseOutput,
-    ParseResult, RecoveryKind, RecoverySalvageClass, RecoverySalvageProfile, RecoverySite,
-    get_error_contexts,
+    BudgetTracker, ErrorCategory, ErrorClass, ErrorContext, ParseBudget, ParseDiagnosticSeverity,
+    ParseError, ParseOutput, ParseResult, RecoveryKind, RecoverySalvageClass,
+    RecoverySalvageProfile, RecoverySite, get_error_contexts,
 };

--- a/crates/perl-parser-core/src/lib.rs
+++ b/crates/perl-parser-core/src/lib.rs
@@ -159,8 +159,8 @@ pub use ast::{GotoTargetForm, Node, NodeKind, SourceLocation};
 pub use error::classifier::{RecoverySalvageMetrics, classify_recovery_salvage};
 /// Parse error, budget, and output types.
 pub use error::{
-    BudgetTracker, ParseBudget, ParseDiagnosticSeverity, ParseError, ParseOutput, ParseResult,
-    RecoverySalvageClass, RecoverySalvageProfile,
+    BudgetTracker, ErrorCategory, ErrorClass, ParseBudget, ParseDiagnosticSeverity, ParseError,
+    ParseOutput, ParseResult, RecoverySalvageClass, RecoverySalvageProfile,
 };
 
 /// Builtin function signature lookup tables.

--- a/crates/perl-parser-core/src/syntax/error/mod.rs
+++ b/crates/perl-parser-core/src/syntax/error/mod.rs
@@ -349,6 +349,50 @@ impl BudgetTracker {
 /// strategies across all pipeline stages.
 pub type ParseResult<T> = Result<T, ParseError>;
 
+/// Operational category used by agentic tooling to route parser failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorCategory {
+    /// The diagnostic is informational and does not describe invalid input.
+    Advisory,
+    /// The input is invalid or needs a user-facing correction.
+    UserError,
+    /// The parser violated an internal invariant.
+    Bug,
+    /// An external dependency or service is unavailable.
+    Infra,
+    /// The operation may succeed if retried.
+    Transient,
+    /// The other side violated a protocol or format contract.
+    Protocol,
+    /// A configured parser safety limit was exceeded.
+    ResourceLimit,
+}
+
+impl ErrorCategory {
+    /// Returns the stable machine token for this category.
+    ///
+    /// The token is part of the public contract: receipt and log layers may
+    /// record it without depending on `Debug` formatting.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Advisory => "advisory",
+            Self::UserError => "user_error",
+            Self::Bug => "bug",
+            Self::Infra => "infra",
+            Self::Transient => "transient",
+            Self::Protocol => "protocol",
+            Self::ResourceLimit => "resource_limit",
+        }
+    }
+}
+
+/// Exposes an operational category for routing and retry decisions.
+pub trait ErrorClass {
+    /// Returns the category that should guide handling of this error.
+    fn error_class(&self) -> ErrorCategory;
+}
+
 /// Severity for a parser diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -509,6 +553,27 @@ pub enum ParseError {
         /// Byte offset of the recovery point in the source.
         location: usize,
     },
+}
+
+impl ErrorClass for ParseError {
+    fn error_class(&self) -> ErrorCategory {
+        // Keep this match exhaustive: adding a ParseError variant must also
+        // choose its routing category before the crate can compile.
+        match self {
+            Self::Advisory { .. } => ErrorCategory::Advisory,
+            Self::Cancelled => ErrorCategory::Transient,
+            Self::RecursionLimit | Self::NestingTooDeep { .. } => ErrorCategory::ResourceLimit,
+            Self::UnexpectedEof
+            | Self::UnexpectedToken { .. }
+            | Self::SyntaxError { .. }
+            | Self::LexerError { .. }
+            | Self::InvalidNumber { .. }
+            | Self::InvalidString
+            | Self::UnclosedDelimiter { .. }
+            | Self::InvalidRegex { .. }
+            | Self::Recovered { .. } => ErrorCategory::UserError,
+        }
+    }
 }
 
 /// Error classification and diagnostic generation for parsed Perl code.
@@ -1170,5 +1235,51 @@ mod tests {
 
         assert_eq!(output.recovered_count, 1);
         assert!(!output.terminated_early);
+    }
+
+    #[test]
+    fn parse_error_routing_distinguishes_operational_classes()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let cases = [
+            (ParseError::UnexpectedEof, ErrorCategory::UserError),
+            (
+                ParseError::Advisory { message: "style".to_string(), location: 0 },
+                ErrorCategory::Advisory,
+            ),
+            (ParseError::RecursionLimit, ErrorCategory::ResourceLimit),
+            (ParseError::NestingTooDeep { depth: 10, max_depth: 5 }, ErrorCategory::ResourceLimit),
+            (ParseError::Cancelled, ErrorCategory::Transient),
+            (
+                ParseError::Recovered {
+                    site: RecoverySite::ArgList,
+                    kind: RecoveryKind::MissingOperand,
+                    location: 0,
+                },
+                ErrorCategory::UserError,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.error_class(), expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn error_category_tokens_are_stable() -> Result<(), Box<dyn std::error::Error>> {
+        let cases = [
+            (ErrorCategory::Advisory, "advisory"),
+            (ErrorCategory::UserError, "user_error"),
+            (ErrorCategory::Bug, "bug"),
+            (ErrorCategory::Infra, "infra"),
+            (ErrorCategory::Transient, "transient"),
+            (ErrorCategory::Protocol, "protocol"),
+            (ErrorCategory::ResourceLimit, "resource_limit"),
+        ];
+
+        for (category, expected) in cases {
+            assert_eq!(category.as_str(), expected);
+        }
+        Ok(())
     }
 }

--- a/crates/perl-parser-core/src/syntax/error/mod.rs
+++ b/crates/perl-parser-core/src/syntax/error/mod.rs
@@ -350,7 +350,7 @@ impl BudgetTracker {
 pub type ParseResult<T> = Result<T, ParseError>;
 
 /// Operational category used by agentic tooling to route parser failures.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum ErrorCategory {
     /// The diagnostic is informational and does not describe invalid input.
@@ -1238,8 +1238,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_error_routing_distinguishes_operational_classes()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn parse_error_routing_distinguishes_operational_classes() {
         let cases = [
             (ParseError::UnexpectedEof, ErrorCategory::UserError),
             (
@@ -1262,11 +1261,10 @@ mod tests {
         for (error, expected) in cases {
             assert_eq!(error.error_class(), expected);
         }
-        Ok(())
     }
 
     #[test]
-    fn error_category_tokens_are_stable() -> Result<(), Box<dyn std::error::Error>> {
+    fn error_category_tokens_are_stable() {
         let cases = [
             (ErrorCategory::Advisory, "advisory"),
             (ErrorCategory::UserError, "user_error"),
@@ -1280,6 +1278,5 @@ mod tests {
         for (category, expected) in cases {
             assert_eq!(category.as_str(), expected);
         }
-        Ok(())
     }
 }

--- a/crates/perl-parser/src/core.rs
+++ b/crates/perl-parser/src/core.rs
@@ -3,7 +3,9 @@
 //! Canonical parser kernel implementation lives in `perl-parser-core`.
 
 pub use perl_parser_core::ast::{Node, NodeKind, SourceLocation};
-pub use perl_parser_core::error::{ParseError, ParseOutput, ParseResult};
+pub use perl_parser_core::error::{
+    ErrorCategory, ErrorClass, ParseError, ParseOutput, ParseResult,
+};
 pub use perl_parser_core::parser::Parser;
 
 pub use perl_parser_core::engine;

--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -369,7 +369,10 @@ pub mod engine;
 pub use engine::{error, parser, position};
 
 /// Recursive descent Perl parser with error recovery and AST generation.
-pub use core::{Node, NodeKind, ParseError, ParseOutput, ParseResult, Parser, SourceLocation};
+pub use core::{
+    ErrorCategory, ErrorClass, Node, NodeKind, ParseError, ParseOutput, ParseResult, Parser,
+    SourceLocation,
+};
 /// Abstract Syntax Tree (AST) definitions for Perl parsing.
 pub use engine::ast;
 /// Experimental second-generation AST (work in progress).

--- a/crates/perl-parser/tests/error_category_tests.rs
+++ b/crates/perl-parser/tests/error_category_tests.rs
@@ -1,0 +1,13 @@
+use perl_parser::{ErrorCategory, ErrorClass, ParseError};
+
+#[test]
+fn parser_facade_exposes_error_classification() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(ParseError::Cancelled.error_class(), ErrorCategory::Transient);
+    assert_eq!(ParseError::UnexpectedEof.error_class(), ErrorCategory::UserError);
+    assert_eq!(ParseError::RecursionLimit.error_class(), ErrorCategory::ResourceLimit);
+    assert_eq!(
+        ParseError::Advisory { message: "valid warning".to_string(), location: 0 }.error_class(),
+        ErrorCategory::Advisory
+    );
+    Ok(())
+}

--- a/crates/perl-parser/tests/error_category_tests.rs
+++ b/crates/perl-parser/tests/error_category_tests.rs
@@ -1,7 +1,7 @@
 use perl_parser::{ErrorCategory, ErrorClass, ParseError};
 
 #[test]
-fn parser_facade_exposes_error_classification() -> Result<(), Box<dyn std::error::Error>> {
+fn parser_facade_exposes_error_classification() {
     assert_eq!(ParseError::Cancelled.error_class(), ErrorCategory::Transient);
     assert_eq!(ParseError::UnexpectedEof.error_class(), ErrorCategory::UserError);
     assert_eq!(ParseError::RecursionLimit.error_class(), ErrorCategory::ResourceLimit);
@@ -9,5 +9,4 @@ fn parser_facade_exposes_error_classification() -> Result<(), Box<dyn std::error
         ParseError::Advisory { message: "valid warning".to_string(), location: 0 }.error_class(),
         ErrorCategory::Advisory
     );
-    Ok(())
 }


### PR DESCRIPTION
## What this does

`ParseError` reaches agentic callers through `perl-parser`'s public error surface with no stable operational category, so a caller cannot tell a style advisory about valid code from malformed input, or a depth limit from a cancelled parse. Routing on `Debug` strings or error text is the only alternative, and it breaks on any wording change.

**Fix:** add `ErrorCategory` and the `ErrorClass` trait to the parser error facade, so every `ParseError` carries a routing category and a stable machine token. Advisories stay advisories, recursion and nesting limits are resource limits, cancellation is transient, and malformed or recovered source is a user error. Existing diagnostics, severities, and syntax-kind APIs are unchanged.

## Verification

`ErrorCategory` is a new public surface, so there is no red/green against `main`: the tests pin the routing contract and the token spelling.

| Check | Result |
| --- | --- |
| routing boundaries | `Advisory` advisory, `RecursionLimit` and `NestingTooDeep` resource_limit, `Cancelled` transient, `UnexpectedEof` and `Recovered` user_error |
| future variants | `match self` is exhaustive, so a new `ParseError` variant fails to compile until it is classified |
| stable tokens | all 7 categories assert their `as_str` spelling |
| facade import path | `perl-parser` re-exports `ErrorCategory` and `ErrorClass` |
| `cargo fmt`, `clippy -D warnings` (lib), `check --all-targets` | clean for both crates |
| `just pr-fast` | 15 passed, 3 blocking failures reproduced on the unpatched parent (`release_history`, `release_history_check`, DAP `test_e2e_scopes_have_no_cross_contamination`) |

## Review map

- `crates/perl-parser-core/src/syntax/error/mod.rs`: defines the category, the trait, `as_str`, and the exhaustive `impl ErrorClass for ParseError`. `ErrorCategory` derives `Hash` so receipt layers can aggregate counts by category.
- `crates/perl-parser-core/src/lib.rs`, `src/engine/error/mod.rs`, `crates/perl-parser/src/{lib,core}.rs`: re-export the contract through the canonical parser surfaces.
- `crates/perl-parser/tests/error_category_tests.rs`: pins the facade import path and the four routing boundaries.
