### PR TITLE
ci(cache): warm merge-gate artifacts after merges (#4827)

### DIFF
--- a/.github/workflows/post-merge-cache-warm.yml
+++ b/.github/workflows/post-merge-cache-warm.yml
@@ -1,0 +1,53 @@
+name: Post-Merge Cargo Cache Warm
+
+# Keep the first PR after a master merge from paying the full cold-build cost.
+# This uses the same cache namespace as the merge-gate jobs in ci.yml, so the
+# compiled workspace and test binaries are reusable by the next PR run.
+#
+# See issue #4827. This is intentionally independent of status regeneration and
+# other post-merge bookkeeping so cache warming can run in parallel with them.
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch: {}
+
+concurrency:
+  group: post-merge-cache-warm-${{ github.ref }}
+  # Let a warm-up finish: cancelling its save phase would recreate the cold-cache
+  # penalty this workflow exists to remove.
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  warm-cargo-cache:
+    name: Warm workspace build and test cache
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # stable (master)
+        with:
+          toolchain: 1.95.0
+
+      - name: Restore and save merge-gate cargo cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: ci-gate-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build workspace
+        run: cargo build --workspace --locked
+
+      - name: Compile workspace tests
+        run: cargo test --workspace --no-run --locked

--- a/xtask/src/tasks/workflow_policy_lint.rs
+++ b/xtask/src/tasks/workflow_policy_lint.rs
@@ -21,6 +21,7 @@ const ALLOWLIST_WORKFLOW_LANE_MISSING: &[&str] = &[
     "chocolatey-bump.yml",
     "docker-publish.yml",
     "docs-deploy.yml",
+    "post-merge-cache-warm.yml",
     "post-merge-corpus-ratchet.yml",
     "post-merge-status.yml",
     "post-publish-smoke.yml",


### PR DESCRIPTION
## What this does

The first pull request after a master merge pays the cold workspace-build cost because post-merge work does not populate the merge-gate cargo cache.

**Change:** Add an independent post-merge cache-warm workflow that uses the exact `ci-gate-${Cargo.lock}` cache namespace, builds the workspace, and compiles all workspace tests so the next PR can reuse the artifacts. Register the utility workflow with the existing workflow-policy allowlist.

## Verification

| Check | Result |
| --- | --- |
| workflow YAML parse | Ruby YAML parser passed |
| workflow policy lint | passed with 21 pre-existing warnings and 0 errors |
| workflow trigger lint | passed; CI Gate trigger contract intact |
| Rust formatting and diff checks | passed |

## Review map

- `.github/workflows/post-merge-cache-warm.yml`: runs after pushes to `main`/`master` and manual dispatch, restores/saves the merge-gate cache, then builds and compiles tests.
- `xtask/src/tasks/workflow_policy_lint.rs`: classifies the post-merge utility as intentionally outside the per-PR lane whitelist.
