### PR TITLE
docs(agent): require decision shapes in specs (#7128)

### DIFF
--- a/.claude/agents/spec-planner.md
+++ b/.claude/agents/spec-planner.md
@@ -34,6 +34,67 @@ implementation.
 
 ## What to produce
 
+### Design shape for decision-heavy work
+
+For work involving a non-trivial state machine, label arithmetic, or rule
+resolution, the checklist must also include a **Design shape** section before
+the change order. It is the builder's executable interpretation of the plan,
+not a second prose summary:
+
+1. **Type signatures first** — name the input, context, and result types. Use
+   Rust-like signatures when the implementation is Rust, or the target
+   language's equivalent when it is not.
+2. **Pseudo-code for the decision function** — show the ordered branches,
+   precedence rules, and explicit fallback for unknown or contradictory input.
+3. **Five to ten worked examples** — show representative, boundary, negative,
+   and ambiguous inputs with their expected result. Keep the examples close to
+   the function they exercise so the red-TDD builder can turn them into tests.
+4. **Unknowns and course-correction boundary** — list what is still genuinely
+   unknown. A builder may return to planning for a new fact discovered during
+   implementation, but may not silently redesign the decision function.
+
+For a simpler issue, write `Design shape: not applicable — the change has no
+state-machine, arithmetic, or rule-resolution decision surface.` This makes the
+skip explicit and keeps the checklist uniform.
+
+#### Worked example: #7071 reconciler resolution
+
+The reconciler's label cleanup should be specified as a typed decision rather
+than a sequence of ad-hoc string checks. The following is an illustrative
+shape; the planner must confirm the actual labels and live signals in the
+issue before handing it to a builder:
+
+```rust
+pub enum LabelClass {
+    LiveSignal(LiveQuery),
+    TimelineBased,
+}
+
+pub enum Resolution {
+    StripA,
+    StripB,
+    LeaveBoth,
+    BothInvalid(Reason),
+}
+
+pub fn resolve(pair: ContradictionPair, ctx: PRContext) -> Resolution;
+```
+
+```text
+if pair.names_are_equal: return BothInvalid(DuplicatePair)
+if either label has a current live-signal query:
+    query the current PR state before using label timestamps
+if both labels describe the same live state: return BothInvalid(ConflictingSignals)
+if exactly one label is contradicted by live state: strip that label
+if only timestamps distinguish the pair: apply the documented freshness rule
+otherwise: return LeaveBoth and emit an actionable unknown-state receipt
+```
+
+The worked-example table should then cover at least: a duplicate pair, each
+single-label contradiction, both labels still valid, simultaneous timestamps,
+missing timestamps, an unknown label, and a live signal that disagrees with
+stored labels. Each row must name the expected `Resolution` and rationale.
+
 For each change in the spec, produce:
 
 1. **File path** — exact path, verified to exist (or "CREATE" if new)

--- a/.claude/commands/spec-planner-plan.md
+++ b/.claude/commands/spec-planner-plan.md
@@ -8,12 +8,48 @@ user-invocable: false
 Produce the implementation checklist. This is the primary artifact —
 the red TDD builder and builder both read this.
 
+For any plan involving a non-trivial state machine, label arithmetic, or rule
+resolution, write the **Design shape** section before `## Change order`. It
+must contain type signatures, ordered pseudo-code for the decision function,
+five to ten worked examples (including negative and ambiguous cases), and a
+short list of genuine unknowns. The worked examples are the acceptance-fixture
+source for the red-TDD builder; do not replace them with general prose.
+
+For plans without those decision surfaces, include the explicit line:
+`Design shape: not applicable — no state-machine, arithmetic, or rule-resolution decision surface.`
+
 ## Checklist format
 
 Write `.spec/<issue#>-<specslug>/checklist.md`:
 
 ```markdown
 # Implementation Checklist: #<issue> — <title>
+
+## Design shape
+
+### Types
+
+```rust
+// Inputs, context, and result types used by the decision function.
+```
+
+### Decision pseudo-code
+
+```text
+// Ordered branches, precedence, and unknown-input fallback.
+```
+
+### Worked examples
+
+| Input | Expected result | Rationale |
+|---|---|---|
+| representative valid case | ... | ... |
+| negative case | ... | ... |
+| ambiguous or missing-data case | ... | ... |
+
+### Genuine unknowns
+
+- <unknown that may require a plan revision during implementation>
 
 ## Change order (compiles at each step)
 

--- a/.claude/commands/spec-planner-plan.md
+++ b/.claude/commands/spec-planner-plan.md
@@ -22,7 +22,7 @@ For plans without those decision surfaces, include the explicit line:
 
 Write `.spec/<issue#>-<specslug>/checklist.md`:
 
-```markdown
+````markdown
 # Implementation Checklist: #<issue> — <title>
 
 ## Design shape
@@ -84,7 +84,7 @@ Files OUT of scope: <everything else — be explicit>
 ## Flags for builder
 
 - <any ambiguities, missing details, or decisions the builder must make>
-```
+````
 
 Write `.spec/<issue#>-<specslug>/acceptance.md`:
 

--- a/docs/reference/PIPELINE_GATES.md
+++ b/docs/reference/PIPELINE_GATES.md
@@ -94,6 +94,16 @@ Agents produce learning artifacts as they work:
 
 **Within-gate ordering**: The verification agents (oppositional, diaboli, architecture, maintainer-issue) read the accuracy-corrected issue from Gate 1 and each other's comments. Each builds on the previous. Plan-reviewer synthesizes all prior verdicts. Spec-planner runs after plan-reviewer, creating the impl branch. See [Within-Gate Ordering](#within-gate-ordering) below for the full ordering.
 
+**Decision-shape requirement**: When the proposed work contains a non-trivial
+state machine, label arithmetic, or rule resolution, the spec-planner output
+must include type signatures, ordered pseudo-code for the decision function,
+five to ten worked examples, and an explicit list of genuine unknowns before
+the builder starts. The examples are the acceptance-fixture source for
+red-TDD. See [the spec-planner design contract](../../.claude/agents/spec-planner.md#design-shape-for-decision-heavy-work)
+and [the checklist format](../../.claude/commands/spec-planner-plan.md#design-shape).
+For simpler work, the checklist must state that the design shape is not
+applicable.
+
 **When to skip Gate 2 entirely**: Skip for trivially-mechanical PRs (fmt cascade fixes, version bumps) where the scope is definitionally unambiguous. The "plan" is "apply the formatter."
 
 **When to skip agents within Gate 2**:


### PR DESCRIPTION
## What this does

State-machine and rule-resolution specs can reach builders without a concrete decision shape, forcing course corrections during implementation.

**Change:** Require spec-planner outputs for this class of work to lead with type signatures, ordered pseudo-code, five to ten worked examples, and explicit genuine unknowns. The contract includes a #7071 reconciler example, a simpler-work skip marker, and Gate 2 cross-references.

## Verification

| Check | Result |
| --- | --- |
| required design-shape sections | present in agent definition and checklist command |
| #7071 worked example | typed result, ordered pseudo-code, and required boundary cases included |
| Gate 2 cross-reference | links to both the agent contract and checklist format |
| links and diff hygiene | referenced files exist; `git diff --check` passes |

## Review map

- `.claude/agents/spec-planner.md`: defines when the contract applies and gives the reconciler example.
- `.claude/commands/spec-planner-plan.md`: makes the design shape a required checklist section and acceptance-fixture source.
- `docs/reference/PIPELINE_GATES.md`: makes the requirement part of Gate 2 and documents the explicit skip for simple work.
