### PR TITLE
docs(vscode): remove stale setting references (#10031)

### DIFF
--- a/book/src/getting-started/configuration.md
+++ b/book/src/getting-started/configuration.md
@@ -516,15 +516,6 @@ Specific release tag (e.g., `v0.8.3`) when channel is set to `tag`.
 
 Trace server communication for debugging.
 
-### `perl-lsp.enableDiagnostics`
-
-| Property | Value |
-|----------|-------|
-| Type | `boolean` |
-| Default | `true` |
-
-Enable real-time syntax diagnostics.
-
 ### `perl-lsp.enableSemanticTokens`
 
 | Property | Value |
@@ -551,15 +542,6 @@ Enable document formatting.
 | Default | `false` |
 
 Format document on save.
-
-### `perl-lsp.enableRefactoring`
-
-| Property | Value |
-|----------|-------|
-| Type | `boolean` |
-| Default | `true` |
-
-Enable advanced refactoring features.
 
 ### `perl-lsp.perltidyConfig`
 

--- a/docs/EXTENSION.md
+++ b/docs/EXTENSION.md
@@ -35,11 +35,9 @@ The Marketplace package is designed to work with `PATH`, `serverPath`, or runtim
 | `perl-lsp.autoDownload` | `true` | Download `perl-lsp` automatically when it is not bundled, configured, or on `PATH`. |
 | `perl-lsp.downloadBaseUrl` | `""` | Override the download host for internal mirrors. |
 | `perl-lsp.trace.server` | `"off"` | LSP trace level: `off`, `messages`, or `verbose`. |
-| `perl-lsp.enableDiagnostics` | `true` | Enable server diagnostics. |
 | `perl-lsp.enableSemanticTokens` | `true` | Enable semantic token highlighting. |
 | `perl-lsp.enableFormatting` | `true` | Enable formatting integration. |
 | `perl-lsp.formatOnSave` | `false` | Request formatting on save. |
-| `perl-lsp.enableRefactoring` | `true` | Enable server-supplied refactoring code actions where supported. |
 | `perl-lsp.perltidyConfig` | `""` | Path to a `.perltidyrc` compatibility file. Native formatting is the default path. |
 | `perl-lsp.includePaths` | `["lib", "local/lib/perl5"]` | Additional Perl include paths passed to the server. |
 | `perl-lsp.enableTestIntegration` | `true` | Enable test integration for `.t` and runnable `.pl` files. |

--- a/docs/how-to/PERFORMANCE_TUNING.md
+++ b/docs/how-to/PERFORMANCE_TUNING.md
@@ -662,11 +662,9 @@ For maximum features with acceptable performance:
 ```json
 {
   "perl-lsp.trace.server": "off",
-  "perl-lsp.enableDiagnostics": true,
   "perl-lsp.enableSemanticTokens": true,
   "perl-lsp.enableFormatting": true,
   "perl-lsp.formatOnSave": false,
-  "perl-lsp.enableRefactoring": true,
   "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"],
   "perl-lsp.useSystemInc": false,
   "perl-lsp.resolutionTimeout": 50,

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -508,11 +508,9 @@ Every `.perl-lsp.toml` setting has a VSCode `settings.json` counterpart. The tab
   "perl-lsp.autoDownload": true,
   "perl-lsp.channel": "latest",
   "perl-lsp.trace.server": "off",
-  "perl-lsp.enableDiagnostics": true,
   "perl-lsp.enableSemanticTokens": true,
   "perl-lsp.enableFormatting": true,
   "perl-lsp.formatOnSave": false,
-  "perl-lsp.enableRefactoring": true,
   "perl-lsp.enableTestIntegration": true,
   "perl-lsp.includePaths": ["lib", "local/lib/perl5"]
 }

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -829,12 +829,18 @@ describe('package.json contributes', () => {
     test('documents the manifest minimum VS Code version and only real settings', () => {
       const setupGuide = readRepoText('docs/EDITORS/VS_CODE_SETUP.md');
       const configReference = readRepoText('docs/reference/CONFIG.md');
+      const canonicalReferences = [
+        readRepoText('docs/EXTENSION.md'),
+        readRepoText('docs/reference/CONFIGURATION.md'),
+        readRepoText('docs/how-to/PERFORMANCE_TUNING.md'),
+        readRepoText('book/src/getting-started/configuration.md'),
+      ];
       const minimumVersion = pkg.engines.vscode.match(/(\d+\.\d+)/)?.[1];
 
       expect(minimumVersion).toBeDefined();
       expect(setupGuide).toContain(`VS Code** version ${minimumVersion} or later`);
 
-      for (const document of [setupGuide, configReference]) {
+      for (const document of [setupGuide, configReference, ...canonicalReferences]) {
         expect(document).not.toContain('perl-lsp.enableDiagnostics');
         expect(document).not.toContain('perl-lsp.enableRefactoring');
       }


### PR DESCRIPTION
Problem: Canonical/reference documentation still advertised the removed `perl-lsp.enableDiagnostics` and `perl-lsp.enableRefactoring` settings after the VS Code manifest cleanup.

Fix: Remove those stale settings from the four remaining documentation surfaces and extend the manifest-derived parity test to cover them.

Verification: `npm run compile:test`, focused configuration Jest (107 passed), `npm run fmt:check`, `git diff --check`, and a targeted repository search all pass.