### PR TITLE
docs(vscode): remove stale schema setting (#10033)

### DIFF
--- a/docs/reference/CONFIGURATION_SCHEMA.md
+++ b/docs/reference/CONFIGURATION_SCHEMA.md
@@ -1344,7 +1344,6 @@ DAP debugging is configured separately via `launch.json` — see [DAP Settings](
 {
   "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"],
   "perl-lsp.useSystemInc": false,
-  "perl-lsp.enableDiagnostics": true,
   "perl-lsp.enableSemanticTokens": true,
   "perl-lsp.enableFormatting": true
 }

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -834,6 +834,7 @@ describe('package.json contributes', () => {
         readRepoText('docs/reference/CONFIGURATION.md'),
         readRepoText('docs/how-to/PERFORMANCE_TUNING.md'),
         readRepoText('book/src/getting-started/configuration.md'),
+        readRepoText('docs/reference/CONFIGURATION_SCHEMA.md'),
       ];
       const minimumVersion = pkg.engines.vscode.match(/(\d+\.\d+)/)?.[1];
 


### PR DESCRIPTION
Problem: `docs/reference/CONFIGURATION_SCHEMA.md` still advertised the removed `perl-lsp.enableDiagnostics` setting.

Fix: Remove the stale schema example entry and extend the manifest-derived documentation parity test to cover the schema reference.

Verification: `npm run compile:test`, focused configuration Jest (107 passed), `npm run fmt:check`, `git diff --check`, and targeted stale-reference search pass.