### PR TITLE
fix(install): correct the Windows installer asset name and the curl-pipe bootstrap (#0000)

### DIFF
--- a/.github/workflows/ci-gate-self-tests.yml
+++ b/.github/workflows/ci-gate-self-tests.yml
@@ -19,6 +19,12 @@ on:
       - 'scripts/install.sh'
       - 'scripts/publish-topo.py'
       - 'scripts/tests/test-install-target-selection.sh'
+      # The Windows install surface and the zero-argument bootstrap path. Both
+      # shipped broken to users because no gate ran on them: install.ps1 was
+      # not in this filter at all, and the documented `curl ... | bash`
+      # invocation was never executed by CI.
+      - 'install.ps1'
+      - 'scripts/tests/test-installer-zero-args.sh'
       - 'scripts/tests/test-publish-dry-run-gate.sh'
       - 'scripts/ci/check-pr-review-convergence'
       - 'scripts/ci/fixtures/convergence/**'
@@ -104,6 +110,31 @@ jobs:
             echo "## Installer target-selection self-test FAILED" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "The installer target-selection contract regressed. Check the step output above for the failed case." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  installer-zero-args-self-test:
+    name: Installer zero-argument bootstrap self-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run installer zero-argument self-test
+        run: bash scripts/tests/test-installer-zero-args.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "## Installer zero-argument self-test passed" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The documented \`curl -fsSL ... | bash\` bootstrap survives \`set -u\`: \`\${BASH_SOURCE[0]}\` is guarded for stdin invocation, empty array expansions use \`\${arr[@]+\"\${arr[@]}\"}\` so bash 3.2 (macOS system bash) does not abort, and positional/flag argument forwarding is unchanged. The bash 3.2 container case runs when Docker is available and SKIPs otherwise." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Installer zero-argument self-test FAILED" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The zero-argument installer bootstrap regressed — the documented curl-pipe command may abort before installing anything. Check the step output above for the failed case." >> "$GITHUB_STEP_SUMMARY"
           fi
 
   check-pr-review-convergence-self-test:

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,11 @@
 # Perl LSP installer for Windows
-# Usage: irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.ps1 | iex
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.ps1 | iex
+#
+# Or from a clone / downloaded copy, to pass options:
+#   .\install.ps1                                    # latest, default dir
+#   .\install.ps1 -Version 0.17.0 -InstallDir C:\tools\bin
 
 param(
     [string]$Version = "latest",
@@ -10,7 +16,17 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 $Repo = "EffortlessMetrics/perl-lsp"
-$Name = "perl-lsp"
+# The release workflow packages the binary as `perllsp` on every platform
+# (see .github/workflows/release.yml — NAME="perllsp"), and every editor doc
+# / README / POSIX installer (scripts/install.sh) uses `perllsp`. Install the
+# Windows binary as `perllsp.exe` so the name matches POSIX and the docs.
+$Name = "perllsp"
+# The release archive also carries the debug adapter (`perl-dap.exe`) — see
+# .github/workflows/release.yml, which builds `-p perl-dap` for every target.
+# Install it alongside the server so Windows matches every sibling channel:
+# scripts/install.sh (optional perl-dap copy), Formula/perllsp.rb,
+# distribution/scoop/perl-lsp.json, distribution/winget/perl-lsp.yaml.
+$DapName = "perl-dap"
 
 function Write-Info {
     param([string]$Message)
@@ -37,17 +53,73 @@ function Write-Success {
     Write-Host $Message
 }
 
-# Detect architecture
-$Arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-    "aarch64"
-} elseif ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") {
-    "x86_64"
+# Detect architecture.
+#
+# Only x86_64-pc-windows-msvc is published: the release matrix in
+# .github/workflows/release.yml has no aarch64-pc-windows-msvc entry. Asking
+# for one built a URL that always 404s, and the failure surfaced as a bare
+# "Failed to download" with nothing actionable in it.
+# See EffortlessMetrics/perl-lsp-swarm#5007.
+#
+# ARM64 Windows runs x64 binaries under emulation on Windows 11 (build 22000
+# or newer), so the x64 asset is the working answer there. Windows 10 ARM64
+# cannot run the published x64 asset and must fail before downloading it.
+#
+# A 32-bit PowerShell host on 64-bit Windows reports "x86" in
+# PROCESSOR_ARCHITECTURE and the real architecture in PROCESSOR_ARCHITEW6432,
+# so consult the latter first.
+$HostArch = if ($env:PROCESSOR_ARCHITEW6432) {
+    $env:PROCESSOR_ARCHITEW6432
 } else {
-    Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+    $env:PROCESSOR_ARCHITECTURE
 }
 
-$Target = "$Arch-pc-windows-msvc"
-Write-Info "Detected system: Windows ($Arch) - $Target"
+$IsArm64Host = $HostArch -eq "ARM64"
+
+function Get-WindowsBuildNumber {
+    try {
+        $build = [int](Get-ItemPropertyValue -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name "CurrentBuildNumber")
+        if ($build -ge 0) {
+            return $build
+        }
+    } catch {
+        # Fall back for restricted registry access or older PowerShell hosts.
+    }
+
+    try {
+        return [int][System.Environment]::OSVersion.Version.Build
+    } catch {
+        return -1
+    }
+}
+
+if ($IsArm64Host) {
+    $WindowsBuild = Get-WindowsBuildNumber
+    if ($WindowsBuild -lt 22000) {
+        $DetectedBuild = if ($WindowsBuild -ge 0) { "build $WindowsBuild" } else { "an unknown Windows build" }
+        Write-Error "Windows ARM64 x64 emulation requires Windows 11 (build 22000 or newer); detected $DetectedBuild. Windows 10 ARM64 cannot run the published x86_64 binary. Build from source: https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/how-to/INSTALLATION.md"
+    }
+}
+
+# Name the target as a whole literal rather than assembling it from an arch
+# variable and a "-pc-windows-msvc" suffix. PowerShell cannot be executed on
+# the Linux CI host, so the contract test in
+# scripts/tests/test-install-target-selection.sh checks which targets this
+# script can request by reading them out of the source. Assembling the triple
+# from a variable hides it from that check, which is how the original defect
+# ($Arch = "aarch64") stayed invisible.
+$Target = if ($IsArm64Host -or $HostArch -eq "AMD64") {
+    "x86_64-pc-windows-msvc"
+} else {
+    Write-Error "Unsupported architecture: $HostArch. Only x86_64 Windows binaries are published. Build from source: https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/how-to/INSTALLATION.md"
+}
+
+if ($IsArm64Host) {
+    Write-Info "Detected system: Windows (ARM64) - installing $Target"
+    Write-Warn "No native ARM64 Windows build is published. The x64 build runs under the x64 emulation in Windows 11 on ARM."
+} else {
+    Write-Info "Detected system: Windows ($HostArch) - $Target"
+}
 
 # Get version
 if ($Version -eq "latest") {
@@ -139,7 +211,26 @@ try {
     Copy-Item -Path $BinaryPath -Destination $DestPath -Force
     
     Write-Success "Installed $Name to $DestPath"
-    
+
+    # Install the perl-dap companion binary when the archive carries it.
+    # Mirrors the optional-DAP copy in scripts/install.sh: present since
+    # v0.9.1, so treat absence as a warning rather than a hard failure to stay
+    # compatible with older archives.
+    $DapInstalled = $false
+    $DapSourcePath = Join-Path $ExtractedDir "$DapName.exe"
+    $DapDestPath = Join-Path $InstallDir "$DapName.exe"
+    if (Test-Path $DapSourcePath) {
+        Write-Info "Installing $DapName to $DapDestPath"
+        if (Test-Path $DapDestPath) {
+            Remove-Item $DapDestPath -Force
+        }
+        Copy-Item -Path $DapSourcePath -Destination $DapDestPath -Force
+        Write-Success "Installed $DapName to $DapDestPath"
+        $DapInstalled = $true
+    } else {
+        Write-Warn "$DapName.exe not found in the release archive - debugging support will be unavailable"
+    }
+
     # Verify installation
     try {
         $VersionOutput = & $DestPath --version 2>&1
@@ -171,6 +262,11 @@ try {
     Write-Host "To get started with Perl LSP:"
     Write-Host "  • VS Code: Install the Perl LSP extension from the marketplace"
     Write-Host "  • Other editors: Configure to use '$DestPath --stdio'"
+    if ($DapInstalled) {
+        Write-Host "  • Debugging: Configure your DAP client to use '$DapDestPath'"
+    } else {
+        Write-Host "  • Debugging: unavailable - $DapName.exe was not in this release archive"
+    }
     Write-Host ""
     Write-Host "For more information: https://github.com/$Repo"
     

--- a/install.ps1
+++ b/install.ps1
@@ -21,12 +21,6 @@ $Repo = "EffortlessMetrics/perl-lsp"
 # / README / POSIX installer (scripts/install.sh) uses `perllsp`. Install the
 # Windows binary as `perllsp.exe` so the name matches POSIX and the docs.
 $Name = "perllsp"
-# The release archive also carries the debug adapter (`perl-dap.exe`) — see
-# .github/workflows/release.yml, which builds `-p perl-dap` for every target.
-# Install it alongside the server so Windows matches every sibling channel:
-# scripts/install.sh (optional perl-dap copy), Formula/perllsp.rb,
-# distribution/scoop/perl-lsp.json, distribution/winget/perl-lsp.yaml.
-$DapName = "perl-dap"
 
 function Write-Info {
     param([string]$Message)
@@ -212,25 +206,6 @@ try {
     
     Write-Success "Installed $Name to $DestPath"
 
-    # Install the perl-dap companion binary when the archive carries it.
-    # Mirrors the optional-DAP copy in scripts/install.sh: present since
-    # v0.9.1, so treat absence as a warning rather than a hard failure to stay
-    # compatible with older archives.
-    $DapInstalled = $false
-    $DapSourcePath = Join-Path $ExtractedDir "$DapName.exe"
-    $DapDestPath = Join-Path $InstallDir "$DapName.exe"
-    if (Test-Path $DapSourcePath) {
-        Write-Info "Installing $DapName to $DapDestPath"
-        if (Test-Path $DapDestPath) {
-            Remove-Item $DapDestPath -Force
-        }
-        Copy-Item -Path $DapSourcePath -Destination $DapDestPath -Force
-        Write-Success "Installed $DapName to $DapDestPath"
-        $DapInstalled = $true
-    } else {
-        Write-Warn "$DapName.exe not found in the release archive - debugging support will be unavailable"
-    }
-
     # Verify installation
     try {
         $VersionOutput = & $DestPath --version 2>&1
@@ -262,11 +237,6 @@ try {
     Write-Host "To get started with Perl LSP:"
     Write-Host "  • VS Code: Install the Perl LSP extension from the marketplace"
     Write-Host "  • Other editors: Configure to use '$DestPath --stdio'"
-    if ($DapInstalled) {
-        Write-Host "  • Debugging: Configure your DAP client to use '$DapDestPath'"
-    } else {
-        Write-Host "  • Debugging: unavailable - $DapName.exe was not in this release archive"
-    }
     Write-Host ""
     Write-Host "For more information: https://github.com/$Repo"
     

--- a/install.sh
+++ b/install.sh
@@ -7,11 +7,26 @@
 
 set -euo pipefail
 
-SCRIPT_SOURCE="${BASH_SOURCE[0]}"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" 2>/dev/null && pwd || pwd)"
-CANONICAL_INSTALLER="$SCRIPT_DIR/scripts/install.sh"
+# `${BASH_SOURCE[0]:-}` — not a bare `${BASH_SOURCE[0]}`. When this script is
+# read from stdin (`curl -fsSL .../install.sh | bash`, the documented bootstrap)
+# BASH_SOURCE is an empty array, and under `set -u` the unguarded expansion
+# aborts with `BASH_SOURCE[0]: unbound variable` before anything is downloaded.
+# A piped invocation has no script directory, so there is no sibling checkout to
+# prefer: leave CANONICAL_INSTALLER empty and fetch the canonical installer.
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
+CANONICAL_INSTALLER=""
+if [ -n "$SCRIPT_SOURCE" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" 2>/dev/null && pwd || pwd)"
+    CANONICAL_INSTALLER="$SCRIPT_DIR/scripts/install.sh"
+fi
 CANONICAL_INSTALLER_URL="https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/scripts/install.sh"
 
+# Every expansion of ARGS below uses `${ARGS[@]+"${ARGS[@]}"}`, never a bare
+# `"${ARGS[@]}"`. Under `set -u`, expanding an empty array as `"${arr[@]}"` is
+# an unbound-variable error on bash < 4.4, and macOS ships /bin/bash 3.2. The
+# documented bootstrap (`curl -fsSL .../install.sh | bash`) is exactly the
+# zero-argument path, so the unguarded form aborts a macOS user's very first
+# command with `ARGS[@]: unbound variable`.
 ARGS=("$@")
 
 if [ "${1:-}" != "" ] && [[ "${1:-}" != -* ]]; then
@@ -30,8 +45,8 @@ if [ "${1:-}" != "" ] && [[ "${1:-}" != -* ]]; then
     ARGS=("$@")
 fi
 
-if [ -f "$CANONICAL_INSTALLER" ]; then
-    exec "$CANONICAL_INSTALLER" "${ARGS[@]}"
+if [ -n "$CANONICAL_INSTALLER" ] && [ -f "$CANONICAL_INSTALLER" ]; then
+    exec "$CANONICAL_INSTALLER" ${ARGS[@]+"${ARGS[@]}"}
 fi
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -42,4 +57,4 @@ fi
 TMP_INSTALLER="$(mktemp)"
 trap 'rm -f "$TMP_INSTALLER"' EXIT
 curl -fsSL "$CANONICAL_INSTALLER_URL" -o "$TMP_INSTALLER"
-exec bash "$TMP_INSTALLER" "${ARGS[@]}"
+exec bash "$TMP_INSTALLER" ${ARGS[@]+"${ARGS[@]}"}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -174,8 +174,15 @@ detect_platform() {
             _libc=""
             ;;
         MINGW*|MSYS*|CYGWIN*)
+            # The PowerShell installer lives at the repository root
+            # (install.ps1), not under scripts/. The scripts/install.ps1 path
+            # this message used to print does not exist and 404s.
             err "Windows is not supported by this script. Use the PowerShell installer instead:
-  irm https://raw.githubusercontent.com/$REPO/master/scripts/install.ps1 | iex"
+  irm https://raw.githubusercontent.com/$REPO/master/install.ps1 | iex
+
+Or download perllsp-<version>-x86_64-pc-windows-msvc.zip from
+https://github.com/$REPO/releases, extract it, and put the folder containing
+perllsp.exe on your PATH."
             ;;
         *)
             err "unsupported operating system: $_os"
@@ -354,7 +361,11 @@ build_from_source() {
         info "building from source for host target"
     fi
 
-    cargo install perllsp --locked "${_target_arg[@]}" --root "$TMPDIR/install-root"
+    # `${_target_arg[@]+"${_target_arg[@]}"}` — a bare `"${_target_arg[@]}"`
+    # would abort under `set -u` on bash < 4.4 (macOS /bin/bash 3.2) whenever
+    # TARGET is unset, which is the default host-target source build.
+    cargo install perllsp --locked ${_target_arg[@]+"${_target_arg[@]}"} \
+        --root "$TMPDIR/install-root"
 
     EXTRACT_DIR="${TMPDIR}/install-root/bin"
 }

--- a/scripts/tests/test-installer-zero-args.sh
+++ b/scripts/tests/test-installer-zero-args.sh
@@ -69,13 +69,24 @@ skip() {
 WORKDIR="$(mktemp -d)"
 
 # A stub that stands in for scripts/install.sh. It reports how many arguments
-# the wrapper forwarded, so a zero-argument bootstrap is observable without
-# touching the network.
+# the wrapper forwarded AND each argument's value, so a zero-argument bootstrap
+# is observable without touching the network and so a wrapper that forwards the
+# wrong argument cannot pass an arity-only assertion.
+#
+# The argument loop is `while [ "$#" -gt 0 ]` + `shift`, not `for a in "$@"`:
+# this stub also runs inside the bash 3.2 container test, where `"$@"` under
+# `set -u` with no positional parameters is itself an unbound-variable error.
 STUB="$WORKDIR/stub-install.sh"
 cat > "$STUB" <<'STUB_EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'STUB argc=%s\n' "$#"
+stub_i=1
+while [ "$#" -gt 0 ]; do
+    printf 'STUB arg%s=%s\n' "$stub_i" "$1"
+    stub_i=$((stub_i + 1))
+    shift
+done
 printf 'STUB VERSION=%s INSTALL_DIR=%s\n' "${VERSION:-}" "${INSTALL_DIR:-}"
 STUB_EOF
 chmod +x "$STUB"
@@ -210,6 +221,126 @@ test_flag_args_forwarded() {
         return
     fi
 
+    # Assert the VALUE, not just the arity: forwarding one wrong argument is
+    # exactly the regression an argc-only assertion cannot see.
+    if ! grep -q 'STUB arg1=--print-target' "$out"; then
+        fail "$label" "expected --print-target to be forwarded verbatim; output: $(cat "$out")"
+        return
+    fi
+
+    pass "$label"
+}
+
+# ── 4b. stdin-mode argument forwarding (the curl-pipe path itself) ───────────
+#
+# Tests 3 and 4 invoke the wrapper as a FILE next to a sibling
+# scripts/install.sh, so they exec the local checkout and never reach the
+# download fallback that install.sh actually changed. The documented
+# argument-carrying bootstrap is
+#
+#     curl -fsSL .../install.sh | bash -s -- 0.17.0 "$HOME/.local/bin"
+#
+# which is stdin mode: BASH_SOURCE is empty, CANONICAL_INSTALLER stays empty,
+# and the wrapper must fetch the canonical installer and forward the remaining
+# arguments to it. `bash -s --` is required; a bare `bash arg < file` would
+# treat the first argument as a script path.
+
+# Deliberately does not touch `set -e`: errexit is a global shell option, so
+# toggling it here would re-enable it before the `return` and abort the whole
+# run on the first intended failure. Callers own the `set +e` / `set -e` pair.
+run_stdin_wrapper() {
+    # usage: run_stdin_wrapper <outfile> [args...]
+    local out="$1"
+    shift
+
+    env PATH="$FAKEBIN:$PATH" PERL_LSP_TEST_STUB_INSTALLER="$STUB" \
+        bash -s -- "$@" <"$ROOT_INSTALLER" >"$out" 2>&1
+}
+
+test_stdin_positional_args() {
+    local label="curl-pipe positional args map to VERSION / INSTALL_DIR"
+    local out="$WORKDIR/out-pipe-args.txt"
+    local status=0
+    local dir="$WORKDIR/pipe-install-dir"
+
+    set +e
+    run_stdin_wrapper "$out" 0.17.0 "$dir"
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "expected exit 0, got $status; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q "STUB VERSION=0.17.0 INSTALL_DIR=$dir" "$out"; then
+        fail "$label" "positional mapping regressed on the stdin path; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB argc=0' "$out"; then
+        fail "$label" "consumed positionals must not also be forwarded; output: $(cat "$out")"
+        return
+    fi
+
+    pass "$label"
+}
+
+test_stdin_flag_args() {
+    local label="curl-pipe forwards flag args verbatim to the downloaded installer"
+    local out="$WORKDIR/out-pipe-flag.txt"
+    local status=0
+
+    set +e
+    run_stdin_wrapper "$out" --print-target --verbose
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "expected exit 0, got $status; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB argc=2' "$out"; then
+        fail "$label" "expected argc=2 on the stdin path; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB arg1=--print-target' "$out" \
+        || ! grep -q 'STUB arg2=--verbose' "$out"; then
+        fail "$label" "flags must be forwarded verbatim and in order; output: $(cat "$out")"
+        return
+    fi
+
+    pass "$label"
+}
+
+test_stdin_mixed_args() {
+    local label="curl-pipe maps positionals and still forwards trailing flags"
+    local out="$WORKDIR/out-pipe-mixed.txt"
+    local status=0
+    local dir="$WORKDIR/pipe-mixed-dir"
+
+    set +e
+    run_stdin_wrapper "$out" 0.17.0 "$dir" --print-target
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "expected exit 0, got $status; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q "STUB VERSION=0.17.0 INSTALL_DIR=$dir" "$out"; then
+        fail "$label" "positional mapping regressed; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB argc=1' "$out" || ! grep -q 'STUB arg1=--print-target' "$out"; then
+        fail "$label" "expected only the trailing flag to be forwarded; output: $(cat "$out")"
+        return
+    fi
+
     pass "$label"
 }
 
@@ -321,6 +452,9 @@ else
     test_file_zero_args
     test_positional_args_still_work
     test_flag_args_forwarded
+    test_stdin_positional_args
+    test_stdin_flag_args
+    test_stdin_mixed_args
     test_no_unguarded_array_expansion
     test_bash_source_guarded
     test_legacy_bash_container

--- a/scripts/tests/test-installer-zero-args.sh
+++ b/scripts/tests/test-installer-zero-args.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Self-test for the ZERO-ARGUMENT installer bootstrap path.
+#
+# Why this test exists (EffortlessMetrics/perl-lsp-swarm#5448):
+#
+# The documented bootstrap is
+#
+#     curl -fsSL https://raw.githubusercontent.com/.../install.sh | bash
+#
+# which is a zero-argument invocation of a script read from stdin, running
+# under `set -euo pipefail`. Two `set -u` hazards live on exactly that path and
+# neither was covered by any gate:
+#
+#   1. `${BASH_SOURCE[0]}` is UNBOUND when the script is read from stdin. This
+#      aborts on every bash version, including current ones — the documented
+#      curl-pipe command was broken on all platforms.
+#   2. `"${ARGS[@]}"` on an EMPTY array is an unbound-variable error on
+#      bash < 4.4. macOS ships /bin/bash 3.2.57, so the zero-argument path
+#      aborted there even when invoked as a file.
+#
+# Hazard 1 reproduces on any bash and is asserted directly below. Hazard 2 does
+# NOT reproduce on bash >= 4.4 (the expansion was made legal in bash 4.4), so it
+# is covered two ways:
+#
+#   - a static assertion that every array expansion in the installers uses the
+#     `${arr[@]+"${arr[@]}"}` guard rather than a bare `"${arr[@]}"`; and
+#   - a real execution under a bash 3.2 container when Docker is available
+#     (skipped, not passed, when it is not).
+#
+# The test never downloads a release artifact: it stubs the canonical installer
+# and `curl`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ROOT_INSTALLER="$ROOT/install.sh"
+CANONICAL_INSTALLER="$ROOT/scripts/install.sh"
+LEGACY_BASH_IMAGE="${PERL_LSP_LEGACY_BASH_IMAGE:-bash:3.2}"
+
+PASS=0
+FAIL=0
+SKIP=0
+WORKDIR=""
+
+cleanup() {
+    if [[ -n "${WORKDIR:-}" && -d "$WORKDIR" ]]; then
+        rm -rf "$WORKDIR"
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    printf 'PASS  %s\n' "$1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    printf 'FAIL  %s\n' "$1"
+    printf '      %s\n' "$2"
+    FAIL=$((FAIL + 1))
+}
+
+skip() {
+    printf 'SKIP  %s\n' "$1"
+    SKIP=$((SKIP + 1))
+}
+
+WORKDIR="$(mktemp -d)"
+
+# A stub that stands in for scripts/install.sh. It reports how many arguments
+# the wrapper forwarded, so a zero-argument bootstrap is observable without
+# touching the network.
+STUB="$WORKDIR/stub-install.sh"
+cat > "$STUB" <<'STUB_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'STUB argc=%s\n' "$#"
+printf 'STUB VERSION=%s INSTALL_DIR=%s\n' "${VERSION:-}" "${INSTALL_DIR:-}"
+STUB_EOF
+chmod +x "$STUB"
+
+# A stub `curl` that serves the stub installer instead of raw.githubusercontent.
+FAKEBIN="$WORKDIR/bin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/curl" <<'CURL_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        -o) out="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+if [[ -z "$out" ]]; then
+    echo "fake curl expected -o <path>" >&2
+    exit 2
+fi
+cp "$PERL_LSP_TEST_STUB_INSTALLER" "$out"
+CURL_EOF
+chmod +x "$FAKEBIN/curl"
+
+# A checkout-shaped tree whose sibling scripts/install.sh is the stub.
+CHECKOUT="$WORKDIR/checkout"
+mkdir -p "$CHECKOUT/scripts"
+cp "$ROOT_INSTALLER" "$CHECKOUT/install.sh"
+cp "$STUB" "$CHECKOUT/scripts/install.sh"
+
+# ── 1. curl-pipe, zero arguments (the exact documented command) ────────────────
+
+test_curl_pipe_zero_args() {
+    local label="curl-pipe zero-arg bootstrap succeeds under set -u"
+    local out="$WORKDIR/out-pipe.txt"
+    local status=0
+
+    set +e
+    env PATH="$FAKEBIN:$PATH" PERL_LSP_TEST_STUB_INSTALLER="$STUB" \
+        bash < "$ROOT_INSTALLER" >"$out" 2>&1
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "expected exit 0, got $status; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB argc=0' "$out"; then
+        fail "$label" "expected the wrapper to forward zero arguments; output: $(cat "$out")"
+        return
+    fi
+
+    pass "$label"
+}
+
+# ── 2. file invocation, zero arguments, local canonical installer present ──────
+
+test_file_zero_args() {
+    local label="file zero-arg invocation forwards no arguments"
+    local out="$WORKDIR/out-file.txt"
+    local status=0
+
+    set +e
+    bash "$CHECKOUT/install.sh" >"$out" 2>&1
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "expected exit 0, got $status; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB argc=0' "$out"; then
+        fail "$label" "expected argc=0; output: $(cat "$out")"
+        return
+    fi
+
+    pass "$label"
+}
+
+# ── 3. positional arguments still map to VERSION / INSTALL_DIR ────────────────
+
+test_positional_args_still_work() {
+    local label="positional version and install dir still become env vars"
+    local out="$WORKDIR/out-args.txt"
+    local status=0
+
+    set +e
+    bash "$CHECKOUT/install.sh" 0.17.0 /tmp/perl-lsp-selftest-bin >"$out" 2>&1
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "expected exit 0, got $status; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB VERSION=0.17.0 INSTALL_DIR=/tmp/perl-lsp-selftest-bin' "$out"; then
+        fail "$label" "positional mapping regressed; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB argc=0' "$out"; then
+        fail "$label" "consumed positionals must not be forwarded; output: $(cat "$out")"
+        return
+    fi
+
+    pass "$label"
+}
+
+# ── 4. flag arguments are forwarded verbatim ─────────────────────────────────
+
+test_flag_args_forwarded() {
+    local label="flag arguments are forwarded to the canonical installer"
+    local out="$WORKDIR/out-flag.txt"
+    local status=0
+
+    set +e
+    bash "$CHECKOUT/install.sh" --print-target >"$out" 2>&1
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "expected exit 0, got $status; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB argc=1' "$out"; then
+        fail "$label" "expected argc=1; output: $(cat "$out")"
+        return
+    fi
+
+    pass "$label"
+}
+
+# ── 5. static guard: no bare "${arr[@]}" expansion in the installers ──────────
+#
+# bash >= 4.4 accepts a bare `"${arr[@]}"` on an empty array, so no amount of
+# running these scripts on a modern bash can catch a regression of the macOS
+# bash 3.2 abort. Assert the guarded spelling directly.
+
+test_no_unguarded_array_expansion() {
+    local label="installers use \${arr[@]+\"\${arr[@]}\"} (bash 3.2 set -u safety)"
+    local offenders=""
+
+    local file
+    for file in "$ROOT_INSTALLER" "$CANONICAL_INSTALLER"; do
+        # Strip comments first, so documentation of the hazard does not register
+        # as the hazard. Then strip the *guarded* spelling
+        # `${arr[@]+"${arr[@]}"}` — it legitimately contains a `"${arr[@]}"`
+        # substring — so only genuinely bare expansions remain.
+        local hits
+        hits="$(sed -e 's/[[:space:]]*#.*$//' \
+                    -e 's/\${\([A-Za-z_][A-Za-z_0-9]*\)\[@\]+"\${\1\[@\]}"}/<GUARDED>/g' \
+                    "$file" \
+            | grep -n '"\${[A-Za-z_][A-Za-z_0-9]*\[@\]}"' || true)"
+        if [[ -n "$hits" ]]; then
+            offenders+="${file}:
+${hits}
+"
+        fi
+    done
+
+    if [[ -n "$offenders" ]]; then
+        fail "$label" "bare array expansions found (use \${arr[@]+\"\${arr[@]}\"}):
+$offenders"
+        return
+    fi
+
+    pass "$label"
+}
+
+# ── 6. static guard: no bare ${BASH_SOURCE[0]} ───────────────────────────────
+
+test_bash_source_guarded() {
+    local label="wrapper guards \${BASH_SOURCE[0]} for stdin invocation"
+
+    local hits
+    hits="$(sed 's/[[:space:]]*#.*$//' "$ROOT_INSTALLER" \
+        | grep -n 'BASH_SOURCE\[0\]}' | grep -v 'BASH_SOURCE\[0\]:-' || true)"
+
+    if [[ -n "$hits" ]]; then
+        fail "$label" "unguarded BASH_SOURCE[0] expansion (curl-pipe aborts under set -u):
+$hits"
+        return
+    fi
+
+    pass "$label"
+}
+
+# ── 7. real bash 3.2 execution when Docker is available ──────────────────────
+
+test_legacy_bash_container() {
+    local label="zero-arg bootstrap runs under bash 3.2 ($LEGACY_BASH_IMAGE)"
+
+    if ! command -v docker >/dev/null 2>&1; then
+        skip "$label (docker not installed)"
+        return
+    fi
+
+    if ! docker info >/dev/null 2>&1; then
+        skip "$label (docker daemon unavailable)"
+        return
+    fi
+
+    if ! docker pull "$LEGACY_BASH_IMAGE" >/dev/null 2>&1; then
+        skip "$label (could not pull $LEGACY_BASH_IMAGE)"
+        return
+    fi
+
+    local out="$WORKDIR/out-legacy.txt"
+    local status=0
+
+    set +e
+    docker run --rm -v "$CHECKOUT:/checkout:ro" -w /checkout \
+        --entrypoint bash "$LEGACY_BASH_IMAGE" \
+        -c 'echo "bash=$BASH_VERSION"; bash /checkout/install.sh' >"$out" 2>&1
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "expected exit 0 under legacy bash, got $status; output: $(cat "$out")"
+        return
+    fi
+
+    if ! grep -q 'STUB argc=0' "$out"; then
+        fail "$label" "expected argc=0 under legacy bash; output: $(cat "$out")"
+        return
+    fi
+
+    printf '      %s\n' "$(grep '^bash=' "$out" || true)"
+    pass "$label"
+}
+
+if [[ ! -f "$ROOT_INSTALLER" ]]; then
+    fail "root installer exists" "missing $ROOT_INSTALLER"
+elif [[ ! -f "$CANONICAL_INSTALLER" ]]; then
+    fail "canonical installer exists" "missing $CANONICAL_INSTALLER"
+else
+    test_curl_pipe_zero_args
+    test_file_zero_args
+    test_positional_args_still_work
+    test_flag_args_forwarded
+    test_no_unguarded_array_expansion
+    test_bash_source_guarded
+    test_legacy_bash_container
+fi
+
+echo
+echo "-- Summary --"
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+echo "Skipped: $SKIP"
+
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Intent

Make the two published install surfaces actually install. Both are broken right
now, on the current release, for every user who follows the documented command.

## Controlling issue

No issue in this repo. The defect is tracked in the development repo as
EffortlessMetrics/perl-lsp-swarm#5461 (asset-name 404),
EffortlessMetrics/perl-lsp-swarm#5007 (ARM64 target that is never built), and
EffortlessMetrics/perl-lsp-swarm#5448 (zero-argument bootstrap). The fixes
already exist there; this PR promotes them. Title carries `(#0000)` per the
unknown-issue convention rather than guessing a number in this repo.

## Defect 1 — `install.ps1` requests an asset that does not exist

`install.ps1` set `$Name = "perl-lsp"` and built `$Asset = "$Name-$VersionNum-$Target.zip"`.
The release workflow packages `NAME="perllsp"` (`.github/workflows/release.yml:151`),
so every release ships `perllsp-*`. The installer has therefore 404'd for every
release, not just the latest.

Live probes against the real v0.17.0 release, taken today:

| Platform target | Asset the published installer requests | Corrected asset | Before | After |
| --- | --- | --- | --- | --- |
| `x86_64-pc-windows-msvc` | `perl-lsp-0.17.0-x86_64-pc-windows-msvc.zip` | `perllsp-0.17.0-x86_64-pc-windows-msvc.zip` | **404** | **200** |

`install.sh` was already correct here — it uses `BIN_NAME="perllsp"`. Confirmed
for every target it can request:

| Platform target | Asset | HTTP |
| --- | --- | --- |
| `x86_64-unknown-linux-gnu` | `perllsp-0.17.0-x86_64-unknown-linux-gnu.tar.gz` | 200 |
| `x86_64-unknown-linux-musl` | `perllsp-0.17.0-x86_64-unknown-linux-musl.tar.gz` | 200 |
| `aarch64-unknown-linux-gnu` | `perllsp-0.17.0-aarch64-unknown-linux-gnu.tar.gz` | 200 |
| `aarch64-unknown-linux-musl` | `perllsp-0.17.0-aarch64-unknown-linux-musl.tar.gz` | 200 |
| `x86_64-apple-darwin` | `perllsp-0.17.0-x86_64-apple-darwin.tar.gz` | 200 |
| `aarch64-apple-darwin` | `perllsp-0.17.0-aarch64-apple-darwin.tar.gz` | 200 |

### Scope of the `$Name` change

`$Name` had five uses. A blind rename risked breaking checksum verification or
the install path, so each was checked against the actual archive. Listing
`perllsp-0.17.0-x86_64-pc-windows-msvc.zip` gives:

```
perllsp-0.17.0-x86_64-pc-windows-msvc/LICENSE-APACHE
perllsp-0.17.0-x86_64-pc-windows-msvc/LICENSE-MIT
perllsp-0.17.0-x86_64-pc-windows-msvc/perl-dap.exe
perllsp-0.17.0-x86_64-pc-windows-msvc/perllsp.exe
perllsp-0.17.0-x86_64-pc-windows-msvc/README.md
perllsp-0.17.0-x86_64-pc-windows-msvc/SHA256SUMS.txt
```

| Use | Wanted `perllsp`? |
| --- | --- |
| `$Asset` download name | yes — this is the 404 |
| `SHA256SUMS` lookup (derives from `$Asset`) | yes — the sums file lists `perllsp-…zip`; the old lookup matched nothing |
| `$ExtractedDir` (archive's internal directory) | yes — the directory is `perllsp-0.17.0-…` |
| `$BinaryPath` (`$Name.exe` inside the archive) | yes — the binary is `perllsp.exe` |
| `$DestPath` (installed filename) | yes — matches the POSIX installer, README, and all editor docs |

All five wanted the same value, so the single assignment is the complete fix.
Nothing needed to stay `perl-lsp`.

## Defect 2 — ARM64 Windows 404s even after the rename

The installer mapped ARM64 hosts to `aarch64-pc-windows-msvc`. The release
matrix has no such entry, so that asset is never produced:

| Asset | HTTP |
| --- | --- |
| `perllsp-0.17.0-aarch64-pc-windows-msvc.zip` | **404** |
| `perl-lsp-0.17.0-aarch64-pc-windows-msvc.zip` | **404** |

The rename alone leaves ARM64 users broken. They now get the x64 build, which
Windows 11 on ARM runs under x64 emulation. Windows 10 ARM64 cannot run it and
is rejected before the download with an actionable message instead of a bare
"Failed to download".

The triple is written as a whole literal rather than assembled from an `$Arch`
variable, so `scripts/tests/test-install-target-selection.sh` can read the
requestable targets out of the source. The original defect assembled it, which
is precisely why no gate saw it.

## The shell installers had three separate defects — all three are fixed here

The asset naming in `install.sh` was **already correct** (it uses
`BIN_NAME="perllsp"`), so it is easy to read this PR as Windows-only. It is not.
Stating each defect and its status explicitly rather than leaving it to be
inferred from the diff:

| # | Defect | Status in this PR |
| --- | --- | --- |
| 3 | `install.sh` expands `${BASH_SOURCE[0]}` unguarded — unbound under `set -u` when read from stdin, i.e. the documented `curl … \| bash` | **Fixed** — guarded as `${BASH_SOURCE[0]:-}` |
| 4 | Bare `"${ARGS[@]}"` / `"${_target_arg[@]}"` on an empty array — unbound-variable abort on bash < 4.4 (macOS ships 3.2) | **Fixed** — all expansions use `${arr[@]+"${arr[@]}"}` in both `install.sh` and `scripts/install.sh` |
| 5 | `scripts/install.sh` sends Windows users to `.../master/scripts/install.ps1`, a path that does not exist | **Fixed** — points at `install.ps1` at the repository root |

None is partially fixed. Verification for each, run against this branch:

**Defect 3.** Unguarded, this is the failure on every bash version and every
platform, before anything is downloaded:

```
$ curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
bash: line 10: BASH_SOURCE[0]: unbound variable
$ echo $?
1
```

After the fix, `install.sh:16` reads `SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"`, and
a piped zero-argument invocation reaches the canonical installer. Asserted by
`test-installer-zero-args.sh` both by execution and by a static check that no
unguarded `${BASH_SOURCE[0]}` returns.

**Defect 4.** bash ≥ 4.4 accepts the bare form, so no amount of running these
scripts on a modern bash catches a regression — the test asserts the spelling
statically. Confirmed zero bare expansions remain in either file:

```
$ # comments and the guarded ${arr[@]+"${arr[@]}"} form stripped first
$ ... install.sh          -> (no bare expansions)
$ ... scripts/install.sh  -> (no bare expansions)
```

**Defect 5.** `scripts/install.sh:181` now emits
`irm https://raw.githubusercontent.com/$REPO/master/install.ps1 | iex`. The old
`scripts/install.ps1` raw URL returns 404; the root `install.ps1` returns 200.

## Behavioral proof

The fixed `install.ps1` was executed end-to-end on real Windows against the
live v0.17.0 release, into a scratch directory:

```
→ Detected system: Windows (AMD64) - x86_64-pc-windows-msvc
→ Downloading from https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.17.0/perllsp-0.17.0-x86_64-pc-windows-msvc.zip
✓ Checksum verified
→ Extracting archive
✓ Installed perllsp to ...\perllsp.exe
✓ Installation verified: perllsp 0.17.0 Git tag: v0.17.0 Perl Language Server using perl-parser v3
Exit code: 0
```

Re-run after the final commit, so this output reflects the branch as it stands
and not an earlier revision.

Checksum verification is genuinely exercised, not skipped — the `SHA256SUMS`
entry matches the downloaded archive:

```
expected (SHA256SUMS): 679cd43780d36cb2a980a42804905d24d2c76b0a3e2deaa3cd344daece87f7dd  perllsp-0.17.0-x86_64-pc-windows-msvc.zip
actual   (downloaded): 679cd43780d36cb2a980a42804905d24d2c76b0a3e2deaa3cd344daece87f7dd
```

The same command with the currently published script, for contrast:

```
→ Downloading from https://github.com/.../perl-lsp-0.17.0-x86_64-pc-windows-msvc.zip
Error: Failed to download from https://github.com/.../perl-lsp-0.17.0-x86_64-pc-windows-msvc.zip : Not Found
Exit code: 1
```

New self-test:

```
$ bash scripts/tests/test-installer-zero-args.sh
PASS  curl-pipe zero-arg bootstrap succeeds under set -u
PASS  file zero-arg invocation forwards no arguments
PASS  positional version and install dir still become env vars
PASS  flag arguments are forwarded to the canonical installer
PASS  installers use ${arr[@]+"${arr[@]}"} (bash 3.2 set -u safety)
PASS  wrapper guards ${BASH_SOURCE[0]} for stdin invocation
SKIP  zero-arg bootstrap runs under bash 3.2 (docker daemon unavailable locally; runs in CI)
Passed: 6  Failed: 0  Skipped: 1
```

The test stubs `curl` and the canonical installer, so it never touches the
network or a release artifact. It fails against the pre-fix `install.sh`.

## Change shape

| File | Change |
| --- | --- |
| `install.ps1` | `$Name` → `perllsp`; ARM64 → x64 with a Windows 10 ARM64 rejection; literal target triple |
| `install.sh` | guard `${BASH_SOURCE[0]}` and empty-array expansions |
| `scripts/install.sh` | correct the Windows hand-off URL; guard the `cargo install` target array for bash 3.2 |
| `scripts/tests/test-installer-zero-args.sh` | new — covers the bootstrap path |
| `.github/workflows/ci-gate-self-tests.yml` | add `install.ps1` to the path filter and run the new test |

## Non-goals

- No release, tag, or workflow dispatch. Nothing is published by this PR.
- No version bump.
- The VS Code extension downloader is **not** touched — see below.
- Installing the `perl-dap.exe` companion binary that the archive already
  carries (and that `scripts/install.sh` installs) is **not** in scope. Windows
  omitting it is a real parity gap, but it is a "we install fewer binaries than
  the POSIX installer" claim, not a "the installer cannot install anything"
  claim — different severity, different rollback. It was in an earlier revision
  of this branch and was deliberately removed so it cannot taint the rollback of
  the 404 fix. Follow-up.

## Known remaining defect, deliberately out of scope

`vscode-extension/src/downloader.ts:865` has the same ARM64 bug that
`install.ps1` had:

```ts
return arch === 'arm64' ? 'aarch64-pc-windows-msvc' : 'x86_64-pc-windows-msvc';
```

That target is never built, so the extension's managed install 404s on ARM64
Windows. It is a live user-facing defect in a different surface with its own
test suite, so it belongs in its own PR rather than widening this one. Tracked
as EffortlessMetrics/perl-lsp-swarm#6196.

Note this is an unpromoted fix, not an unfixed defect: the development repo's
`downloader.ts` is already correct — it rejects unsupported Windows 10 ARM64 and
returns `x86_64-pc-windows-msvc`. Only this repo's copy is stale.

This has a concrete consequence for review: the development repo's version of
`scripts/tests/test-install-target-selection.sh` contains a contract check that
asserts every install surface requests only targets the release matrix builds.
Promoting that check here would fail on `downloader.ts` today. It is therefore
**not** included in this PR, and the Windows target contract remains ungated
until the extension is fixed. Verified directly — running the development
repo's test against this tree reports:

```
FAIL  extension downloader requests only built Windows targets
      requests Windows target(s) the release matrix never builds: aarch64-pc-windows-msvc
```

## What was not run

- No CI run existed at authoring time; the self-test job is new here.
- The bash 3.2 container case SKIPs locally (no Docker) and runs in CI.
- macOS and Linux installs were not executed end-to-end. Their asset URLs were
  verified by HTTP probe (table above) and `install.sh`'s naming was already
  correct and is unchanged by this PR.
- ARM64 Windows was not executed on real ARM64 hardware; the target selection
  and the Windows 10 rejection are covered by source-level assertions.

## Claim boundary

This PR proves that the Windows installer downloads, checksum-verifies,
extracts, installs, and runs the real v0.17.0 artifact, and that the
documented curl-pipe command no longer aborts under `set -u`. It does not
claim the VS Code extension's managed install works on ARM64 Windows — it does
not.

## Risk & rollback

Low. Changes are confined to install scripts, one new test, and a CI path
filter; no library, binary, or packaging code is touched. The installed binary
filename changes from `perl-lsp.exe` to `perllsp.exe` on Windows — but since
the installer has never successfully installed anything, no existing user can
be relying on the old name from this path. `perllsp` is what the README, the
POSIX installer, the Homebrew formula, and the Scoop/winget manifests already
use, so this removes a naming inconsistency rather than creating one. Rollback
is a revert of this commit.


## Review-driven test hardening (`0032466a5`)

CodeRabbit found that the argument tests did not exercise the path this PR
changed. It was right, and the finding is fixed rather than dispositioned away.

`test_positional_args_still_work` and `test_flag_args_forwarded` invoke the
wrapper as a **file** beside a stub `scripts/install.sh`, so they take the
`exec "$CANONICAL_INSTALLER"` branch and never reach the download fallback at
`install.sh:60`. The flag test also asserted only `argc=1`, so it passed for any
single forwarded argument.

- the stub now prints `STUB arg<N>=<value>` for every argument;
- the flag test asserts the forwarded **value**, not the arity;
- three new stdin-mode tests drive the real bootstrap shape
  (`bash -s -- … < install.sh`, i.e. `curl … | bash -s --`): positional, flag,
  and mixed arguments, asserting the mapped `VERSION`/`INSTALL_DIR` and the
  verbatim forwarded flags.

Two mutations prove the new tests discriminate:

| Mutation | Result |
| --- | --- |
| `install.sh` reverted to its pre-fix `origin/master` state | 3 pass / 6 fail — the two sibling-path tests stay **green**; all three new stdin tests go red with `BASH_SOURCE[0]: unbound variable` |
| `BASH_SOURCE` fix kept, but a fixed `--wrong-flag` forwarded in place of `ARGS` | 6 pass / 3 fail — arity stays `argc=1`, so the **old** assertion would still have passed; the new one fails with `expected --print-target to be forwarded verbatim` |

Restored: 9 passed, 0 failed, 1 skipped (bash 3.2 container, no local Docker;
it runs in CI). `Installer zero-argument bootstrap self-test` is green on CI at
this head.
