### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,33 @@
+name: Trustabl Agent Scanner
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+# Minimal top-level permissions; write grants are scoped to the scan job only.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: trustabl-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+    # continue-on-error keeps this job advisory — findings are reported but
+    # CI does not go red so unrelated work is never blocked.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: trustabl/trustabl-action@973f666d20b5fbb2e6a4511bd3846e965a08c28b # v0.4.1
+        with:
+          version: v0.1.6


### PR DESCRIPTION
We came across your repo and we like that it provides a Rust-based solution for interacting with the Perl ecosystem, combining both parsing and language server functionality. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Project default permission mode bypasses approvals
   What it means: The project's .claude/config.yml file uses a `default_permission` mode that bypasses approval requirements for subagents. 
   Why it matters: This can lead to unintended access and modifications by subagents without proper oversight or authorization, potentially compromising the system's security.

2. [HIGH] Subagent granted filesystem-write or web-fetch built-ins
   File: .claude/agents/research-web.md
   What it means: This subagent's frontmatter grants a filesystem-write (`Write`/`Edit`) or web-fetch (`WebFetch`) built-in. 
   Why it matters: Granting filesystem write access to a subagent can allow it to modify files on the system, potentially leading to data corruption or malicious code execution. Similarly, granting web-fetch capabilities can expose sensitive information or enable unauthorized access to external resources.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)