### PR TITLE
ci(sync): require the audited 0.18.0-rc.1 publication join (#10088)

### DIFF
--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -66,3 +66,10 @@ workflow = ".github/workflows/ux-regression-gate.yml"
 [[checks]]
 name = "Merge Gate"
 workflow = ".github/workflows/ci.yml"
+
+[[checks]]
+name = "Publication Sync Contract"
+workflow = ".github/workflows/publication-sync-contract.yml"
+required = true
+enforcement = "github-ruleset"
+reason = "Audited 0.18.0-rc.1 publication join enforcement (perl-lsp#10088, perl-lsp-swarm#12231): fail closed on declared sync PRs; deterministic not_applicable on ordinary PRs. Required live on master via ruleset 8029855."

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,17 @@ like (#0000) or (#9999) will fail CI.
 - [ ] substrate
 - [ ] reliability
 
+## Publication Sync
+<!--
+  Ordinary PRs: leave the marker below as `no`.
+  An explicit publication-sync PR for the audited 0.18.0-rc.1 join sets it to
+  `yes` AND commits the packet at .github/publication-sync/packet.yaml (see
+  schemas/publication_sync.v2.schema.json). Both markers together are the
+  authority that puts the `Publication Sync Contract` check into sync mode;
+  a title substring is not authority. Mismatched markers fail closed.
+-->
+- Publication-sync PR (yes/no): no
+
 ## Claim Boundary
 <!-- What changes, and what does this PR explicitly not claim? -->
 

--- a/.github/workflows/publication-sync-contract.yml
+++ b/.github/workflows/publication-sync-contract.yml
@@ -1,0 +1,122 @@
+name: Publication Sync Contract
+
+# Enforcement check for the audited 0.18.0-rc.1 publication join on master
+# (EffortlessMetrics/perl-lsp-swarm#12231, tracked in perl-lsp as #10088).
+#
+# Two modes:
+#   ordinary PR                  -> deterministic `not_applicable` success
+#   explicit publication-sync PR -> fail closed unless the exact packet,
+#                                   ancestry, tree, and no-publish contract
+#                                   pass (proofs 1-11 of the controlling issue)
+#
+# Sync mode requires BOTH repository-owned markers: the committed packet at
+# .github/publication-sync/packet.yaml in the PR head tree AND the dedicated
+# PR-template field `- Publication-sync PR (yes/no): yes`. A title substring
+# is not authority.
+#
+# Least privilege by construction: read-only repository permissions, no
+# secrets, no publication credential, and a validator that runs only git
+# inspection plumbing. The permission/command ratchet lives in
+# scripts/tests/test-publication-sync-contract.py. The validator executed in
+# CI is taken from the trusted PR base, never from the untrusted head.
+#
+# Required status context: the job name below IS the check context; it must
+# stay exactly `Publication Sync Contract` (ratcheted by the test above and
+# required live on master by ruleset 8029855).
+
+on:
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
+    inputs:
+      merge_sha:
+        description: "Wrapper merge commit M landing on master (post-merge verification)"
+        required: true
+
+concurrency:
+  group: publication-sync-contract-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: Publication Sync Contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout PR head with full history
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Ensure the PR base commit is present
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null || \
+            git fetch --no-tags origin "${BASE_SHA}"
+
+      - name: Run publication sync contract check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # The validator comes from the trusted base ref so an untrusted PR
+          # head cannot weaken its own gate. Bootstrap exception: the PR that
+          # introduces the check has no validator at its base yet; only that
+          # PR may fall back to the head copy, and it is exactly the PR under
+          # review for introducing the gate.
+          if git show "${BASE_SHA}:scripts/publication_sync_check.py" \
+              > "${RUNNER_TEMP}/publication_sync_check.py" 2>/dev/null; then
+            echo "Validator source: PR base ${BASE_SHA}"
+          else
+            echo "::notice::Validator absent at base; bootstrap fallback to the PR head copy (valid only for the PR introducing this check)"
+            cp scripts/publication_sync_check.py "${RUNNER_TEMP}/publication_sync_check.py"
+          fi
+          printf '%s' "${PR_BODY}" > "${RUNNER_TEMP}/pr-body.txt"
+          python3 "${RUNNER_TEMP}/publication_sync_check.py" pr \
+            --repo . \
+            --base-sha "${BASE_SHA}" \
+            --head-sha "${HEAD_SHA}" \
+            --pr-body-file "${RUNNER_TEMP}/pr-body.txt"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            if [ "${{ job.status }}" = "success" ]; then
+              echo "## Publication Sync Contract: passed"
+              echo ""
+              echo "Ordinary PRs report deterministic \`not_applicable\`; declared sync PRs proved the exact R/S/J packet, ancestry, tree, and no-publish contract."
+            else
+              echo "## Publication Sync Contract: FAILED"
+              echo ""
+              echo "The check fails closed. See the job log for the named failing proof (1-11)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  post-merge:
+    name: Publication Sync Post-Merge Verification
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout master with full history
+        uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Verify the wrapper merge preserved the audited join
+        env:
+          MERGE_SHA: ${{ inputs.merge_sha }}
+        run: |
+          python3 scripts/publication_sync_check.py post-merge \
+            --repo . \
+            --merge-sha "${MERGE_SHA}" \
+            --master-ref refs/heads/master

--- a/.github/workflows/publication-sync-contract.yml
+++ b/.github/workflows/publication-sync-contract.yml
@@ -9,10 +9,11 @@ name: Publication Sync Contract
 #                                   ancestry, tree, and no-publish contract
 #                                   pass (proofs 1-11 of the controlling issue)
 #
-# Sync mode requires BOTH repository-owned markers: the committed packet at
-# .github/publication-sync/packet.yaml in the PR head tree AND the dedicated
-# PR-template field `- Publication-sync PR (yes/no): yes`. A title substring
-# is not authority.
+# Sync mode requires BOTH repository-owned markers: a packet introduced or
+# changed by this PR at .github/publication-sync/packet.yaml AND the
+# dedicated PR-template field `- Publication-sync PR (yes/no): yes`. A title
+# substring is not authority; an unchanged inherited packet is not sync
+# content.
 #
 # Least privilege by construction: read-only repository permissions, no
 # secrets, no publication credential, and a validator that runs only git
@@ -26,6 +27,10 @@ name: Publication Sync Contract
 
 on:
   pull_request:
+    # `edited` is required: the PR body carries one of the two sync-mode
+    # authorities (the marker field), so a body edit must re-run the check
+    # rather than leave a stale success on an unchanged head.
+    types: [opened, edited, reopened, synchronize]
     branches: [master, main]
   workflow_dispatch:
     inputs:

--- a/schemas/publication_sync.v2.schema.json
+++ b/schemas/publication_sync.v2.schema.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/schemas/publication_sync.v2.schema.json",
+  "title": "publication_sync.v2",
+  "description": "Publication Sync Contract for the audited 0.18.0-rc.1 join on perl-lsp/master (EffortlessMetrics/perl-lsp-swarm#12231). The packet is committed at .github/publication-sync/packet.yaml in the sync PR head J. Packet bytes must be JSON-parseable (JSON is valid YAML 1.2) so validation stays deterministic on the Python standard library. The reconciliation ledger and projection manifest live at the fixed sibling paths .github/publication-sync/reconciliation-ledger.json and .github/publication-sync/projection-manifest.json; the packet binds them by sha256 digest.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "release",
+    "release_base_sha",
+    "prepared_swarm_sha",
+    "sync_join_sha",
+    "expected_join_parents",
+    "reconciliation_digest",
+    "publication_sync_manifest_digest",
+    "expected_projected_tree",
+    "published_channels",
+    "release_cut"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "v0.18_publication_sync.v2"
+    },
+    "release": {
+      "const": "0.18.0-rc.1"
+    },
+    "release_base_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "R: exact publication base commit; must equal the PR base."
+    },
+    "prepared_swarm_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "S: exact prepared swarm commit; must be the second parent of J."
+    },
+    "sync_join_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "J: audited two-parent complete-tree join; must equal the PR head."
+    },
+    "expected_join_parents": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{40}$"
+      },
+      "description": "Ordered parents of J; must equal [release_base_sha, prepared_swarm_sha]."
+    },
+    "reconciliation_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "sha256 of the committed reconciliation ledger bytes at tree(J)."
+    },
+    "publication_sync_manifest_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "sha256 of the committed projection manifest bytes at tree(J)."
+    },
+    "expected_projected_tree": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Expected tree object id of J (the reviewed projection)."
+    },
+    "published_channels": {
+      "type": "array",
+      "maxItems": 0,
+      "description": "No-publish contract: must be empty at sync time."
+    },
+    "release_cut": {
+      "const": false,
+      "description": "No-publish contract: the sync PR never cuts a release."
+    }
+  },
+  "$defs": {
+    "reconciliation_ledger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "release",
+        "decisions",
+        "blockers"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "v0.18_reconciliation.v1"
+        },
+        "release": {
+          "const": "0.18.0-rc.1"
+        },
+        "decisions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "status"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "status": {
+                "const": "resolved",
+                "description": "Blocker-free contract: every decision must be resolved. blocked, not_proven, or any other status fails closed."
+              },
+              "summary": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "blockers": {
+          "type": "array",
+          "maxItems": 0
+        }
+      }
+    },
+    "projection_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "release",
+        "translations",
+        "exclusions",
+        "required_invariants"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "v0.18_publication_sync_manifest.v1"
+        },
+        "release": {
+          "const": "0.18.0-rc.1"
+        },
+        "translations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "from",
+              "to"
+            ],
+            "properties": {
+              "from": {
+                "$ref": "#/$defs/repo_path"
+              },
+              "to": {
+                "$ref": "#/$defs/repo_path"
+              }
+            }
+          }
+        },
+        "exclusions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/repo_path"
+          }
+        },
+        "required_invariants": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "status"
+            ],
+            "properties": {
+              "id": {
+                "enum": [
+                  "destination-context",
+                  "version",
+                  "topology",
+                  "artifact-reachability",
+                  "effective-identity"
+                ]
+              },
+              "status": {
+                "const": "pass",
+                "description": "Fail-closed contract: only an explicit pass is accepted; not_proven or any other status fails."
+              },
+              "evidence": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "One entry per named invariant class: destination-context, version, topology, artifact-reachability, effective-identity. The independent projection verifier that produces this evidence lands with the sibling producer issues; this contract consumes the recorded evidence and fails closed on anything but an explicit pass."
+        }
+      }
+    },
+    "repo_path": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.@+-][A-Za-z0-9_.@+/-]{0,255}$",
+      "not": {
+        "pattern": "(^|/)\\.\\.?(/|$)"
+      }
+    }
+  }
+}

--- a/scripts/publication_sync_check.py
+++ b/scripts/publication_sync_check.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Publication Sync Contract validator for the audited 0.18.0-rc.1 join.
+
+Implements EffortlessMetrics/perl-lsp-swarm#12231 in perl-lsp. Two modes:
+
+    ordinary PR                    -> deterministic ``not_applicable`` success
+    explicit publication-sync PR   -> fail closed unless the exact packet,
+                                      ancestry, tree, and no-publish contract
+                                      all pass
+
+Sync mode requires BOTH repository-owned markers:
+
+1. the committed packet at ``.github/publication-sync/packet.yaml`` in the
+   PR head tree, and
+2. the dedicated PR-template field ``- Publication-sync PR (yes/no): yes``
+   in the PR body.
+
+A title substring is not authority. A packet without the field, or the field
+without a packet, fails closed: sync content may not slip through undeclared,
+and a declared sync may not arrive without its packet.
+
+Commit-identity design (why ``sync_join_sha`` is the *core* join):
+
+The packet is committed inside the PR head J, so it cannot literally name
+J's own commit id (a commit cannot contain its own hash). The producer
+therefore builds two commits with identical parents ``[R, S]``, message, and
+author/committer identity:
+
+    J0 = core join: tree is exactly the reviewed projection
+    J  = PR head:   tree is the projection plus the control-plane directory
+                    .github/publication-sync/ (packet, ledger, manifest)
+
+``sync_join_sha`` names J0. Proof 2 re-derives J0 from J (same metadata and
+declared parents, tree = projection) and requires an exact match, and proof 7
+requires the derived projection tree to equal ``expected_projected_tree``.
+Together they prove the PR head is precisely "audited join + control files"
+and nothing else. ``git diff S..J`` is likewise compared against the manifest
+with the control directory excluded.
+
+The packet bytes must be JSON-parseable (JSON is valid YAML 1.2) so this
+validator stays deterministic on the Python standard library. The durable
+contract is ``schemas/publication_sync.v2.schema.json``.
+
+This script holds no publication authority: it runs only git inspection
+plumbing plus local object construction (``mktree``/``commit-tree`` write
+loose objects into the local object store and mutate neither refs, index,
+nor working tree), and it uses no credential. The permission/command ratchet
+lives in ``scripts/tests/test-publication-sync-contract.py``.
+
+Subcommands:
+
+    pr          Pre-merge contract on exact PR base/head (proofs 1-11 of the
+                controlling issue).
+    post-merge  Bounded verifier for the wrapper merge M: J is an ancestor
+                of M, tree(M) == tree(J), R and S are ancestors of M, and
+                current master == M. A squash/rebase landing fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, NoReturn, Optional, Sequence, Tuple
+
+PACKET_PATH = ".github/publication-sync/packet.yaml"
+LEDGER_PATH = ".github/publication-sync/reconciliation-ledger.json"
+MANIFEST_PATH = ".github/publication-sync/projection-manifest.json"
+# Control-plane directory: packet, ledger, and manifest live here. These
+# files are the contract, not the projection, so they are excluded from the
+# projection-tree derivation and from the S..J path-set comparison.
+CONTROL_DIR = ".github/publication-sync/"
+CONTROL_DIR_PARENT = ".github"
+CONTROL_DIR_NAME = "publication-sync"
+
+SCHEMA_VERSION = "v0.18_publication_sync.v2"
+LEDGER_SCHEMA_VERSION = "v0.18_reconciliation.v1"
+MANIFEST_SCHEMA_VERSION = "v0.18_publication_sync_manifest.v1"
+RELEASE = "0.18.0-rc.1"
+
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+REPO_PATH = re.compile(r"^[A-Za-z0-9_.@+-][A-Za-z0-9_.@+/-]{0,255}$")
+MARKER_FIELD = re.compile(
+    r"^[ \t]*-[ \t]*Publication-sync PR[^:\n]*:[ \t]*(yes|no)[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+IDENT = re.compile(r"^(.*?) <(.*?)> (\d+) ([+-]\d{4})$")
+REQUIRED_INVARIANT_IDS = (
+    "destination-context",
+    "version",
+    "topology",
+    "artifact-reachability",
+    "effective-identity",
+)
+
+PACKET_KEYS = {
+    "schema_version",
+    "release",
+    "release_base_sha",
+    "prepared_swarm_sha",
+    "sync_join_sha",
+    "expected_join_parents",
+    "reconciliation_digest",
+    "publication_sync_manifest_digest",
+    "expected_projected_tree",
+    "published_channels",
+    "release_cut",
+}
+
+
+class ContractFailure(Exception):
+    """A named contract proof failed. Never a success path."""
+
+
+def fail(message: str) -> NoReturn:
+    raise ContractFailure(message)
+
+
+def run_git(repo: Path, args: Sequence[str], *, input_text: Optional[str] = None,
+            env: Optional[Dict[str, str]] = None) -> str:
+    """Run a git command; instrument failure is not success."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        input=input_text,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        fail(f"git {' '.join(args)} failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    return proc.stdout
+
+
+def git_ok(repo: Path, args: Sequence[str]) -> bool:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def tree_file(repo: Path, commit: str, path: str) -> Optional[bytes]:
+    """Bytes of ``path`` at ``commit``; None when absent."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{commit}:{path}"],
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def sha256_prefixed(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def load_json_bytes(data: bytes, what: str) -> Any:
+    try:
+        return json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"{what} is not valid JSON-shaped YAML: {exc}")
+
+
+def require_hex40(value: Any, what: str) -> str:
+    if not isinstance(value, str) or not HEX40.match(value):
+        fail(f"{what} must be a 40-char lowercase hex sha, got {value!r}")
+    return value
+
+
+def check_marker_field(body: str) -> Optional[bool]:
+    """Parse the dedicated PR-template marker field.
+
+    Returns True (yes), False (no), or None (absent). Conflicting values
+    fail closed: an ambiguous declaration is not authority either.
+    """
+    values = {m.group(1).lower() for m in MARKER_FIELD.finditer(body)}
+    if not values:
+        return None
+    if len(values) > 1:
+        fail("PR body carries conflicting Publication-sync PR marker values")
+    return values.pop() == "yes"
+
+
+def validate_packet_shape(packet: Any) -> dict:
+    """Hand-rolled strict validation against schemas/publication_sync.v2.schema.json."""
+    if not isinstance(packet, dict):
+        fail("packet must be a JSON object")
+    keys = set(packet)
+    missing = PACKET_KEYS - keys
+    extra = keys - PACKET_KEYS
+    if missing:
+        fail(f"packet missing required keys: {sorted(missing)}")
+    if extra:
+        fail(f"packet carries unknown keys: {sorted(extra)}")
+    if packet["schema_version"] != SCHEMA_VERSION:
+        fail(f"packet schema_version must be {SCHEMA_VERSION}, got {packet['schema_version']!r}")
+    if packet["release"] != RELEASE:
+        fail(f"packet release must be {RELEASE}, got {packet['release']!r}")
+    require_hex40(packet["release_base_sha"], "release_base_sha")
+    require_hex40(packet["prepared_swarm_sha"], "prepared_swarm_sha")
+    require_hex40(packet["sync_join_sha"], "sync_join_sha")
+    require_hex40(packet["expected_projected_tree"], "expected_projected_tree")
+    parents = packet["expected_join_parents"]
+    if (
+        not isinstance(parents, list)
+        or len(parents) != 2
+        or any(not isinstance(p, str) or not HEX40.match(p) for p in parents)
+    ):
+        fail("expected_join_parents must be exactly two 40-char hex shas")
+    for key in ("reconciliation_digest", "publication_sync_manifest_digest"):
+        if not isinstance(packet[key], str) or not DIGEST.match(packet[key]):
+            fail(f"{key} must match sha256:<64 hex>, got {packet[key]!r}")
+    if packet["published_channels"] != []:
+        fail(f"no-publish contract: published_channels must be [], got {packet['published_channels']!r}")
+    if packet["release_cut"] is not False:
+        fail(f"no-publish contract: release_cut must be false, got {packet['release_cut']!r}")
+    return packet
+
+
+def validate_ledger(ledger: Any) -> None:
+    allowed = {"schema_version", "release", "decisions", "blockers"}
+    if not isinstance(ledger, dict):
+        fail("reconciliation ledger must be a JSON object")
+    if set(ledger) - allowed:
+        fail(f"reconciliation ledger carries unknown keys: {sorted(set(ledger) - allowed)}")
+    if ledger.get("schema_version") != LEDGER_SCHEMA_VERSION:
+        fail(f"ledger schema_version must be {LEDGER_SCHEMA_VERSION}, got {ledger.get('schema_version')!r}")
+    if ledger.get("release") != RELEASE:
+        fail(f"ledger release must be {RELEASE}, got {ledger.get('release')!r}")
+    if ledger.get("blockers") != []:
+        fail(f"reconciliation ledger is not blocker-free: {ledger.get('blockers')!r}")
+    decisions = ledger.get("decisions")
+    if not isinstance(decisions, list):
+        fail("reconciliation ledger decisions must be an array")
+    for decision in decisions:
+        if not isinstance(decision, dict) or not isinstance(decision.get("id"), str):
+            fail("each reconciliation decision needs a string id")
+        # Fail closed: only an explicit resolved decision is accepted. A
+        # blocked or not_proven decision can never read as pass (proof 11).
+        if decision.get("status") != "resolved":
+            fail(
+                f"reconciliation decision {decision.get('id')!r} has status "
+                f"{decision.get('status')!r}; only 'resolved' is acceptable"
+            )
+
+
+def validate_manifest(manifest: Any) -> dict:
+    allowed = {"schema_version", "release", "translations", "exclusions", "required_invariants"}
+    if not isinstance(manifest, dict):
+        fail("projection manifest must be a JSON object")
+    if set(manifest) - allowed:
+        fail(f"projection manifest carries unknown keys: {sorted(set(manifest) - allowed)}")
+    if manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        fail(f"manifest schema_version must be {MANIFEST_SCHEMA_VERSION}, got {manifest.get('schema_version')!r}")
+    if manifest.get("release") != RELEASE:
+        fail(f"manifest release must be {RELEASE}, got {manifest.get('release')!r}")
+    translations = manifest.get("translations")
+    exclusions = manifest.get("exclusions")
+    if not isinstance(translations, list) or not isinstance(exclusions, list):
+        fail("manifest translations and exclusions must be arrays")
+    listed_paths = set()
+    for translation in translations:
+        if not isinstance(translation, dict):
+            fail("each translation must be an object with from/to")
+        for key in ("from", "to"):
+            value = translation.get(key)
+            if not isinstance(value, str) or not REPO_PATH.match(value) or ".." in value.split("/"):
+                fail(f"translation {key} must be a safe repo-relative path, got {value!r}")
+            listed_paths.add(value)
+    for path in exclusions:
+        if not isinstance(path, str) or not REPO_PATH.match(path) or ".." in path.split("/"):
+            fail(f"exclusion must be a safe repo-relative path, got {path!r}")
+        listed_paths.add(path)
+    invariants = manifest.get("required_invariants")
+    if not isinstance(invariants, list):
+        fail("manifest required_invariants must be an array")
+    seen = set()
+    for invariant in invariants:
+        if not isinstance(invariant, dict) or not isinstance(invariant.get("id"), str):
+            fail("each required invariant needs a string id")
+        seen.add(invariant["id"])
+        # Fail closed: required uncertainty (not_proven or anything else) is
+        # never a pass (proof 11).
+        if invariant.get("status") != "pass":
+            fail(
+                f"required invariant {invariant['id']!r} has status "
+                f"{invariant.get('status')!r}; only 'pass' is acceptable"
+            )
+    missing_ids = [i for i in REQUIRED_INVARIANT_IDS if i not in seen]
+    if missing_ids:
+        fail(f"manifest omits required invariants: {missing_ids}")
+    return {"listed_paths": listed_paths}
+
+
+def ls_tree(repo: Path, treeish: str) -> List[str]:
+    """Non-recursive ls-tree lines (``mode type sha\\tname``), or [] if absent."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "ls-tree", treeish],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+    return [line for line in proc.stdout.splitlines() if line]
+
+
+def mktree(repo: Path, entries: List[str]) -> str:
+    """Build a tree object from ls-tree-format lines (git sorts them)."""
+    return run_git(repo, ["mktree"], input_text="\n".join(entries) + ("\n" if entries else "")).strip()
+
+
+def projected_tree(repo: Path, commit: str) -> str:
+    """Tree of ``commit`` with the control-plane directory excluded.
+
+    Removes ``.github/publication-sync``; drops ``.github`` entirely when it
+    becomes empty (git trees conventionally omit empty subtrees).
+    """
+    root_entries = ls_tree(repo, commit)
+    if not root_entries:
+        fail(f"{commit} has no readable root tree")
+    rebuilt_root = []
+    for entry in root_entries:
+        meta, _, name = entry.partition("\t")
+        if name != CONTROL_DIR_PARENT:
+            rebuilt_root.append(entry)
+            continue
+        sub_entries = [
+            sub
+            for sub in ls_tree(repo, f"{commit}:{CONTROL_DIR_PARENT}")
+            if sub.partition("\t")[2] != CONTROL_DIR_NAME
+        ]
+        if sub_entries:
+            new_sub = mktree(repo, sub_entries)
+            mode = meta.split(" ", 1)[0]
+            rebuilt_root.append(f"{mode} tree {new_sub}\t{CONTROL_DIR_PARENT}")
+        # else: .github held only the control directory; drop it.
+    return mktree(repo, rebuilt_root)
+
+
+def commit_metadata(repo: Path, commit: str) -> Tuple[Dict[str, str], str]:
+    """(author/committer env, message bytes) of a commit."""
+    raw = run_git(repo, ["cat-file", "commit", commit])
+    header, sep, message = raw.partition("\n\n")
+    if not sep:
+        fail(f"{commit} has a malformed commit object")
+    env = dict(os.environ)
+    found = set()
+    for line in header.splitlines():
+        for role, prefix in (("AUTHOR", "author "), ("COMMITTER", "committer ")):
+            if line.startswith(prefix):
+                match = IDENT.match(line[len(prefix):])
+                if not match:
+                    fail(f"{commit} has an unparseable {prefix.strip()} ident: {line!r}")
+                name, email, ts, tz = match.groups()
+                env[f"GIT_{role}_NAME"] = name
+                env[f"GIT_{role}_EMAIL"] = email
+                env[f"GIT_{role}_DATE"] = f"{ts} {tz}"
+                found.add(role)
+    if found != {"AUTHOR", "COMMITTER"}:
+        fail(f"{commit} is missing author/committer idents")
+    return env, message
+
+
+def derive_core_join(repo: Path, commit: str, parents: Sequence[str]) -> str:
+    """Rebuild the core join: same metadata/message/parents, projection tree."""
+    env, message = commit_metadata(repo, commit)
+    tree = projected_tree(repo, commit)
+    args = ["commit-tree", tree]
+    for parent in parents:
+        args += ["-p", parent]
+    return run_git(repo, args, input_text=message, env=env).strip()
+
+
+def check_pr(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    require_hex40(args.base_sha, "--base-sha")
+    require_hex40(args.head_sha, "--head-sha")
+    body = Path(args.pr_body_file).read_text(encoding="utf-8") if args.pr_body_file else ""
+    body = body.replace("\r\n", "\n").replace("\r", "\n")  # GitHub bodies may be CRLF
+    marker = check_marker_field(body)
+
+    packet_bytes = tree_file(repo, args.head_sha, PACKET_PATH)
+
+    # Mode decision. Both markers are repository-owned; a title substring is
+    # never consulted.
+    if packet_bytes is None and marker is not True:
+        # Deterministic non-sync success (positive control 1).
+        print("not_applicable: no committed packet and marker field is not 'yes'")
+        print("publication-sync: not_applicable")
+        return 0
+    if packet_bytes is None:
+        fail("declared publication-sync PR (marker field 'yes') without a committed packet")
+    if marker is not True:
+        fail(
+            "committed publication-sync packet present without the PR-template "
+            "marker field set to 'yes'; sync content may not arrive undeclared"
+        )
+
+    packet = validate_packet_shape(load_json_bytes(packet_bytes, "publication-sync packet"))
+    base_r = packet["release_base_sha"]
+    swarm_s = packet["prepared_swarm_sha"]
+    core_join = packet["sync_join_sha"]
+
+    # Packet self-consistency: declared parents are exactly [R, S].
+    if packet["expected_join_parents"] != [base_r, swarm_s]:
+        fail("expected_join_parents must equal [release_base_sha, prepared_swarm_sha]")
+
+    # Proof 1: PR base equals declared R.
+    if args.base_sha != base_r:
+        fail(f"proof 1: PR base {args.base_sha} != declared release_base_sha {base_r}")
+    print(f"PASS proof 1: PR base == R ({base_r})")
+
+    # Proof 2: PR head re-derives exactly the declared core join J0 (same
+    # parents, message, and identity; tree = projection without control
+    # files). See the module docstring for why J0 is the core join.
+    try:
+        derived = derive_core_join(repo, args.head_sha, [base_r, swarm_s])
+    except ContractFailure as exc:
+        fail(f"proof 2: {exc}")
+    if derived != core_join:
+        fail(
+            f"proof 2: PR head re-derives core join {derived}, "
+            f"declared sync_join_sha is {core_join}"
+        )
+    print(f"PASS proof 2: PR head is exactly declared join {core_join} plus control files")
+
+    # Proof 3: J has exactly two ordered parents [R, S].
+    parents_line = run_git(repo, ["rev-list", "--parents", "-n", "1", args.head_sha]).split()
+    if parents_line != [args.head_sha, base_r, swarm_s]:
+        fail(f"proof 3: J parents are {parents_line[1:]}, expected [{base_r}, {swarm_s}]")
+    print("PASS proof 3: J has exactly two ordered parents [R, S]")
+
+    # Proof 4: S resolves to the exact prepared swarm commit and is reachable from J.
+    if not git_ok(repo, ["cat-file", "-e", f"{swarm_s}^{{commit}}"]):
+        fail(f"proof 4: prepared swarm commit {swarm_s} does not resolve")
+    if not git_ok(repo, ["merge-base", "--is-ancestor", swarm_s, args.head_sha]):
+        fail(f"proof 4: S {swarm_s} is not reachable from J {args.head_sha}")
+    print("PASS proof 4: S resolves and is reachable from J")
+
+    # Proof 5: final reconciliation ledger is valid, blocker-free, digest-matched.
+    ledger_bytes = tree_file(repo, args.head_sha, LEDGER_PATH)
+    if ledger_bytes is None:
+        fail(f"proof 5: reconciliation ledger missing at {LEDGER_PATH} in tree(J)")
+    if sha256_prefixed(ledger_bytes) != packet["reconciliation_digest"]:
+        fail("proof 5: reconciliation ledger digest mismatch")
+    try:
+        validate_ledger(load_json_bytes(ledger_bytes, "reconciliation ledger"))
+    except ContractFailure as exc:
+        fail(f"proof 5: {exc}")
+    print("PASS proof 5: reconciliation ledger valid, blocker-free, digest-matched")
+
+    # Proof 6: publication projection manifest is valid and digest-matched.
+    manifest_bytes = tree_file(repo, args.head_sha, MANIFEST_PATH)
+    if manifest_bytes is None:
+        fail(f"proof 6: projection manifest missing at {MANIFEST_PATH} in tree(J)")
+    if sha256_prefixed(manifest_bytes) != packet["publication_sync_manifest_digest"]:
+        fail("proof 6: projection manifest digest mismatch")
+    try:
+        manifest = validate_manifest(load_json_bytes(manifest_bytes, "projection manifest"))
+    except ContractFailure as exc:
+        fail(f"proof 6: {exc}")
+    print("PASS proof 6: projection manifest valid and digest-matched")
+
+    # Proof 7: tree(J) with the control directory excluded equals
+    # expected_projected_tree.
+    actual_tree = projected_tree(repo, args.head_sha)
+    if actual_tree != packet["expected_projected_tree"]:
+        fail(
+            f"proof 7: projected tree(J) {actual_tree} != expected_projected_tree "
+            f"{packet['expected_projected_tree']}"
+        )
+    print(f"PASS proof 7: tree(J) == expected_projected_tree ({actual_tree})")
+
+    # Proof 8: git diff S..J contains exactly manifest-listed
+    # translations/exclusions (control-plane directory excluded).
+    diff_output = run_git(repo, ["diff", "--name-only", swarm_s, args.head_sha])
+    changed = {
+        line.strip()
+        for line in diff_output.splitlines()
+        if line.strip() and not line.strip().startswith(CONTROL_DIR)
+    }
+    listed = manifest["listed_paths"]
+    unlisted = sorted(changed - listed)
+    missing = sorted(listed - changed)
+    if unlisted:
+        fail(f"proof 8: paths differ from S without a manifest entry: {unlisted}")
+    if missing:
+        fail(f"proof 8: manifest-listed paths absent from the S..J diff: {missing}")
+    print(f"PASS proof 8: S..J diff is exactly the {len(listed)} manifest-listed path(s)")
+
+    # Proof 9: every named invariant passed (enforced inside validate_manifest).
+    print("PASS proof 9: destination-context, version, topology, artifact-reachability, "
+          "effective-identity invariants all pass")
+
+    # Proof 10: no-publish contract (shape-validated above; restated for the log).
+    print("PASS proof 10: published_channels == [] and release_cut == false; "
+          "check holds read-only permissions and no publication credential")
+
+    # Proof 11: enforced structurally — every missing, unknown, or uncertain
+    # input above is a hard failure, never a success.
+    print("PASS proof 11: no missing/skipped/uncertain evidence was accepted as success")
+
+    print("publication-sync: pass")
+    return 0
+
+
+def check_post_merge(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    merge_m = require_hex40(args.merge_sha, "--merge-sha")
+    master_ref = args.master_ref
+
+    packet_bytes = tree_file(repo, merge_m, PACKET_PATH)
+    if packet_bytes is None:
+        fail(f"no publication-sync packet at {PACKET_PATH} in tree(M); nothing to verify")
+    packet = validate_packet_shape(load_json_bytes(packet_bytes, "publication-sync packet"))
+    base_r = packet["release_base_sha"]
+    swarm_s = packet["prepared_swarm_sha"]
+
+    # The PR head J is re-derived from the packet-declared core join the same
+    # way as in pre-merge mode, then the wrapper M must preserve J itself.
+    # J is the commit whose tree contains this packet; locate it as the
+    # second parent of M first (GitHub wrapper merges carry the PR head as
+    # second parent), then verify.
+    parents_line = run_git(repo, ["rev-list", "--parents", "-n", "1", merge_m]).split()
+    if len(parents_line) < 2:
+        fail(f"post-merge: M {merge_m} has no parents; not a wrapper merge")
+    join_j = parents_line[2] if len(parents_line) == 3 else None
+    if join_j is None:
+        fail(
+            f"post-merge: M {merge_m} has parents {parents_line[1:]}; "
+            "expected exactly two (master tip, PR head J) — squash/rebase landing?"
+        )
+
+    # J is an ancestor of M (direct second parent here) and must re-derive
+    # the declared core join, binding M to the audited packet.
+    derived = derive_core_join(repo, join_j, [base_r, swarm_s])
+    if derived != packet["sync_join_sha"]:
+        fail(
+            f"post-merge: second parent of M re-derives {derived}, "
+            f"declared sync_join_sha is {packet['sync_join_sha']}"
+        )
+    if not git_ok(repo, ["merge-base", "--is-ancestor", join_j, merge_m]):
+        fail(f"post-merge: J {join_j} is not an ancestor of M {merge_m} (squash/rebase landing?)")
+    print(f"PASS post-merge: J ({join_j}) is an ancestor of M ({merge_m})")
+
+    # tree(M) == tree(J): the wrapper added nothing.
+    tree_m = run_git(repo, ["rev-parse", f"{merge_m}^{{tree}}"]).strip()
+    tree_j = run_git(repo, ["rev-parse", f"{join_j}^{{tree}}"]).strip()
+    if tree_m != tree_j:
+        fail(f"post-merge: tree(M) {tree_m} != tree(J) {tree_j}")
+    print(f"PASS post-merge: tree(M) == tree(J) ({tree_j})")
+
+    for name, sha in (("R", base_r), ("S", swarm_s)):
+        if not git_ok(repo, ["merge-base", "--is-ancestor", sha, merge_m]):
+            fail(f"post-merge: {name} {sha} is not an ancestor of M {merge_m}")
+        print(f"PASS post-merge: {name} ({sha}) is an ancestor of M")
+
+    current = run_git(repo, ["rev-parse", master_ref]).strip()
+    if current != merge_m:
+        fail(f"post-merge: current {master_ref} is {current}, expected M {merge_m}")
+    print(f"PASS post-merge: current {master_ref} == M ({merge_m})")
+
+    print("publication-sync post-merge: pass")
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    pr = sub.add_parser("pr", help="pre-merge publication-sync contract")
+    pr.add_argument("--repo", required=True)
+    pr.add_argument("--base-sha", required=True)
+    pr.add_argument("--head-sha", required=True)
+    pr.add_argument("--pr-body-file", default=None)
+
+    pm = sub.add_parser("post-merge", help="post-merge wrapper verification")
+    pm.add_argument("--repo", required=True)
+    pm.add_argument("--merge-sha", required=True)
+    pm.add_argument("--master-ref", default="refs/heads/master")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "pr":
+            return check_pr(args)
+        return check_post_merge(args)
+    except ContractFailure as exc:
+        # GitHub Actions annotation syntax; also readable in local output.
+        print(f"::error::Publication Sync Contract FAILED: {exc}")
+        return 1
+    except Exception as exc:  # instrument failure is never success
+        print(f"::error::Publication Sync Contract instrument failure: {exc!r}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publication_sync_check.py
+++ b/scripts/publication_sync_check.py
@@ -10,14 +10,19 @@ Implements EffortlessMetrics/perl-lsp-swarm#12231 in perl-lsp. Two modes:
 
 Sync mode requires BOTH repository-owned markers:
 
-1. the committed packet at ``.github/publication-sync/packet.yaml`` in the
-   PR head tree, and
+1. a packet at ``.github/publication-sync/packet.yaml`` INTRODUCED OR CHANGED
+   by this PR relative to its base (an unchanged packet inherited from
+   master is not sync content — after a sync lands, master carries its
+   packet because post-merge requires ``tree(M) == tree(J)``, so mere
+   presence would fail every later ordinary PR closed forever), and
 2. the dedicated PR-template field ``- Publication-sync PR (yes/no): yes``
    in the PR body.
 
-A title substring is not authority. A packet without the field, or the field
-without a packet, fails closed: sync content may not slip through undeclared,
-and a declared sync may not arrive without its packet.
+A title substring is not authority. A fresh packet without the field, the
+field without a fresh packet, or the field with a stale (base-identical)
+packet all fail closed: sync content may not slip through undeclared, a
+declared sync may not arrive without its packet, and a stale packet cannot
+re-prove an old join.
 
 Commit-identity design (why ``sync_join_sha`` is the *core* join):
 
@@ -77,6 +82,9 @@ MANIFEST_PATH = ".github/publication-sync/projection-manifest.json"
 CONTROL_DIR = ".github/publication-sync/"
 CONTROL_DIR_PARENT = ".github"
 CONTROL_DIR_NAME = "publication-sync"
+# Exact inventory of the control directory: anything beyond these three
+# files is unreviewed content invisible to the tree/diff proofs.
+CONTROL_DIR_FILES = {"packet.yaml", "reconciliation-ledger.json", "projection-manifest.json"}
 
 SCHEMA_VERSION = "v0.18_publication_sync.v2"
 LEDGER_SCHEMA_VERSION = "v0.18_reconciliation.v1"
@@ -391,20 +399,35 @@ def check_pr(args: argparse.Namespace) -> int:
     marker = check_marker_field(body)
 
     packet_bytes = tree_file(repo, args.head_sha, PACKET_PATH)
+    base_packet_bytes = tree_file(repo, args.base_sha, PACKET_PATH)
 
     # Mode decision. Both markers are repository-owned; a title substring is
-    # never consulted.
-    if packet_bytes is None and marker is not True:
-        # Deterministic non-sync success (positive control 1).
-        print("not_applicable: no committed packet and marker field is not 'yes'")
+    # never consulted. The packet signal is relative to the PR base: once a
+    # sync lands, master carries its packet (post-merge requires
+    # tree(M) == tree(J)), so mere presence cannot mean sync mode — every
+    # later ordinary PR would otherwise fail closed forever. Only a packet
+    # INTRODUCED OR CHANGED by this PR is sync content.
+    packet_changed = packet_bytes is not None and packet_bytes != base_packet_bytes
+    if not packet_changed and marker is not True:
+        # Deterministic non-sync success (positive control 1). Covers no
+        # packet anywhere and an unchanged inherited packet alike.
+        print("not_applicable: no packet introduced or changed by this PR and "
+              "marker field is not 'yes'")
         print("publication-sync: not_applicable")
         return 0
     if packet_bytes is None:
         fail("declared publication-sync PR (marker field 'yes') without a committed packet")
+    if not packet_changed:
+        fail(
+            "declared publication-sync PR carries a packet identical to the PR "
+            "base; a sync declaration requires a fresh packet (stale packets "
+            "cannot re-prove an old join)"
+        )
     if marker is not True:
         fail(
-            "committed publication-sync packet present without the PR-template "
-            "marker field set to 'yes'; sync content may not arrive undeclared"
+            "publication-sync packet introduced or changed without the "
+            "PR-template marker field set to 'yes'; sync content may not "
+            "arrive undeclared"
         )
 
     packet = validate_packet_shape(load_json_bytes(packet_bytes, "publication-sync packet"))
@@ -415,6 +438,22 @@ def check_pr(args: argparse.Namespace) -> int:
     # Packet self-consistency: declared parents are exactly [R, S].
     if packet["expected_join_parents"] != [base_r, swarm_s]:
         fail("expected_join_parents must equal [release_base_sha, prepared_swarm_sha]")
+
+    # Control-directory inventory: exactly packet, ledger, manifest. Anything
+    # extra would be invisible to both the projection-tree identity and the
+    # S..J path-set comparison (the directory is excluded from both), so an
+    # unlisted file here would defeat the exact-tree guarantee.
+    control_entries = ls_tree(
+        repo, f"{args.head_sha}:{CONTROL_DIR_PARENT}/{CONTROL_DIR_NAME}"
+    )
+    control_names = {entry.partition("\t")[2] for entry in control_entries}
+    control_extra = sorted(control_names - CONTROL_DIR_FILES)
+    control_missing = sorted(CONTROL_DIR_FILES - control_names)
+    if control_extra:
+        fail(f"control directory carries unreviewed files: {control_extra}")
+    if control_missing:
+        fail(f"control directory is missing contract files: {control_missing}")
+    print("PASS control-dir: control directory holds exactly packet, ledger, manifest")
 
     # Proof 1: PR base equals declared R.
     if args.base_sha != base_r:

--- a/scripts/tests/test-publication-sync-contract.py
+++ b/scripts/tests/test-publication-sync-contract.py
@@ -181,8 +181,8 @@ class SyncFixture:
       ledger / manifest — replace the artifact payloads;
       projection_extra  — extra files in the projection AND the packet's
                           expected tree (consistent producer change);
-      head_extra        — extra files only in J's tree, outside the control
-                          directory (post-packet tree drift);
+      head_extra        — extra files only in J's tree (post-packet tree
+                          drift; may target the control directory);
       head_parents      — actual parents of J (default [R, S]).
     """
 
@@ -499,6 +499,41 @@ class PublicationSyncContractTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("publication-sync: pass", proc.stdout)
 
+    def ordinary_commit_on(self, parent: str) -> str:
+        """Ordinary follow-up commit reusing the parent's exact tree."""
+        tree = self.repo.git("rev-parse", f"{parent}^{{tree}}")
+        return self.repo.git("commit-tree", tree, "-p", parent, input_bytes=b"ordinary\n")
+
+    def test_inherited_packet_is_not_applicable(self) -> None:
+        # After a sync lands, master carries its packet (tree(M) == tree(J)).
+        # An ordinary PR whose head inherits that packet unchanged must NOT
+        # enter sync mode, or every later PR would fail closed forever.
+        fixture = SyncFixture(self.repo)
+        head = self.ordinary_commit_on(fixture.j)
+        proc = self.run_pr(fixture, BODY_NO, base=fixture.j, head=head)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("publication-sync: not_applicable", proc.stdout)
+
+    def test_declared_sync_with_stale_packet_fails(self) -> None:
+        # Marker yes but the packet is byte-identical to the base: a stale
+        # packet cannot re-prove an old join.
+        fixture = SyncFixture(self.repo)
+        head = self.ordinary_commit_on(fixture.j)
+        proc = self.run_pr(fixture, BODY_YES, base=fixture.j, head=head)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("stale packet", proc.stdout)
+
+    def test_extra_control_dir_file_fails(self) -> None:
+        # Anything beyond packet/ledger/manifest in the control directory is
+        # invisible to the tree and diff proofs, so it must fail the gate.
+        fixture = SyncFixture(
+            self.repo,
+            head_extra={".github/publication-sync/unreviewed.txt": b"smuggled\n"},
+        )
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("unreviewed files", proc.stdout)
+
 
 class ValidatorUnitTest(unittest.TestCase):
     """Pure-function guards that need no git fixture."""
@@ -557,6 +592,13 @@ class RatchetTest(unittest.TestCase):
         # drift silently.
         self.assertTrue(text.startswith("name: Publication Sync Contract\n"))
         self.assertIn("\n    name: Publication Sync Contract\n", text)
+
+    def test_workflow_reruns_on_body_edits(self) -> None:
+        # The PR body carries one sync-mode authority (the marker field), so
+        # the workflow must trigger on `edited` or a body flip would leave a
+        # stale success on an unchanged head.
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("types: [opened, edited, reopened, synchronize]", text)
 
     def test_schema_file_matches_validator(self) -> None:
         schema = json.loads(SCHEMA.read_text(encoding="utf-8"))

--- a/scripts/tests/test-publication-sync-contract.py
+++ b/scripts/tests/test-publication-sync-contract.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""Tests for scripts/publication_sync_check.py — Publication Sync Contract.
+
+Covers the shift-left falsifiers and positive controls of
+EffortlessMetrics/perl-lsp-swarm#12231 against synthetic Git graphs:
+
+Positive controls:
+  1. ordinary PR returns deterministic ``not_applicable`` success;
+  2. exact synthetic [R,S] join and projected tree pass;
+  3. simulated wrapper M preserving J passes post-merge verification.
+
+Falsifiers (each must reject):
+  - sync mode without a packet;
+  - committed packet without the marker field;
+  - wrong PR base;
+  - head not equal to declared J (core-join re-derivation mismatch);
+  - one-parent or reversed-parent join;
+  - correct parents with wrong tree;
+  - correct tree without reachable S ancestry (shallow clone);
+  - one unlisted path differing from S;
+  - reconciliation with a blocking decision or unmatched digest;
+  - required NOT_PROVEN represented as pass;
+  - ordinary PR accidentally entering sync mode from its title;
+  - simulated GitHub squash wrapper;
+  - any public mutation permission or command in the sync check.
+
+Plus a permission/context ratchet on .github/workflows/publication-sync-contract.yml
+and drift guards binding the validator to the committed schema and PR template.
+
+Run with: python3 scripts/tests/test-publication-sync-contract.py
+Exit code 0 on all-pass, 1 on any failure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = SCRIPTS_DIR.parent
+CHECK = SCRIPTS_DIR / "publication_sync_check.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publication-sync-contract.yml"
+SCHEMA = REPO_ROOT / "schemas" / "publication_sync.v2.schema.json"
+PR_TEMPLATE = REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+
+PACKET_PATH = ".github/publication-sync/packet.yaml"
+LEDGER_PATH = ".github/publication-sync/reconciliation-ledger.json"
+MANIFEST_PATH = ".github/publication-sync/projection-manifest.json"
+
+RELEASE = "0.18.0-rc.1"
+FIXED_ENV = {
+    "GIT_AUTHOR_NAME": "Sync Fixture",
+    "GIT_AUTHOR_EMAIL": "sync-fixture@example.invalid",
+    "GIT_AUTHOR_DATE": "1700000000 +0000",
+    "GIT_COMMITTER_NAME": "Sync Fixture",
+    "GIT_COMMITTER_EMAIL": "sync-fixture@example.invalid",
+    "GIT_COMMITTER_DATE": "1700000000 +0000",
+}
+JOIN_MESSAGE = "join 0.18.0-rc.1 audited projection\n"
+
+BODY_YES = "## Publication Sync\n\n- Publication-sync PR (yes/no): yes\n"
+BODY_NO = "## Publication Sync\n\n- Publication-sync PR (yes/no): no\n"
+BODY_ABSENT = "ordinary pull request body\n"
+# Title-like prose is not authority: mentions the sync everywhere except the
+# dedicated marker field.
+BODY_TITLE_LIKE = (
+    "publication sync: land the audited 0.18.0-rc.1 join\n\n"
+    "This PR is the publication-sync join for R/S/J.\n\n"
+    "- Publication-sync PR (yes/no): no\n"
+)
+
+
+def json_bytes(payload: dict) -> bytes:
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+class Repo:
+    """Minimal plumbing-only synthetic repo builder."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        path.mkdir(parents=True, exist_ok=True)
+        self.git("init", "-q")
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.git("config", "user.name", "Fixture")
+
+    def git(self, *args: str, input_bytes: bytes | None = None) -> str:
+        env = dict(os.environ)
+        env.update(FIXED_ENV)
+        proc = subprocess.run(
+            ["git", "-C", str(self.path), *args],
+            input=input_bytes,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise AssertionError(
+                f"git {' '.join(args)} failed: {proc.stderr.decode(errors='replace')}"
+            )
+        return proc.stdout.decode().strip()
+
+    def make_tree(self, files: dict[str, bytes]) -> str:
+        self.git("read-tree", "--empty")
+        for path, content in sorted(files.items()):
+            blob = self.git("hash-object", "-w", "--stdin", input_bytes=content)
+            self.git("update-index", "--add", "--cacheinfo", f"100644,{blob},{path}")
+        return self.git("write-tree")
+
+    def make_commit(self, files: dict[str, bytes], parents: list[str], message: str) -> str:
+        tree = self.make_tree(files)
+        args = ["commit-tree", tree]
+        for parent in parents:
+            args += ["-p", parent]
+        return self.git(*args, input_bytes=message.encode())
+
+
+def ledger_payload(status: str = "resolved") -> dict:
+    return {
+        "schema_version": "v0.18_reconciliation.v1",
+        "release": RELEASE,
+        "decisions": [{"id": "d1", "status": status, "summary": "fixture decision"}],
+        "blockers": [],
+    }
+
+
+def invariant_payload(status: str = "pass") -> list[dict]:
+    return [
+        {"id": inv, "status": status, "evidence": "synthetic fixture"}
+        for inv in (
+            "destination-context",
+            "version",
+            "topology",
+            "artifact-reachability",
+            "effective-identity",
+        )
+    ]
+
+
+def manifest_payload(status: str = "pass") -> dict:
+    return {
+        "schema_version": "v0.18_publication_sync_manifest.v1",
+        "release": RELEASE,
+        "translations": [{"from": "docs/old.md", "to": "docs/new.md"}],
+        "exclusions": ["tmp/skip.txt"],
+        "required_invariants": invariant_payload(status),
+    }
+
+
+S_CONTENT = {
+    "app/main.pl": b"use strict; use warnings;\n",
+    "docs/old.md": b"old docs\n",
+    "tmp/skip.txt": b"scratch\n",
+    # A populated .github directory exercises the projection-tree subtree
+    # rebuild (the real J keeps .github/workflows alongside the control dir).
+    ".github/workflows/ci.yml": b"name: CI\n",
+}
+# Projection: docs/old.md translated to docs/new.md, tmp/skip.txt excluded.
+PROJECTION_CONTENT = {
+    "app/main.pl": S_CONTENT["app/main.pl"],
+    "docs/new.md": b"new docs\n",
+    ".github/workflows/ci.yml": S_CONTENT[".github/workflows/ci.yml"],
+}
+
+
+class SyncFixture:
+    """Producer-side builder mirroring the future sibling-tooling output.
+
+    Builds R, S, the core join J0 (projection tree, parents [R, S]), and the
+    PR head J (projection plus the control-plane directory, identical message
+    and identity) exactly as scripts/publication_sync_check.py documents.
+
+    Tamper hooks:
+      packet_override   — merged into the packet before it is committed;
+      ledger / manifest — replace the artifact payloads;
+      projection_extra  — extra files in the projection AND the packet's
+                          expected tree (consistent producer change);
+      head_extra        — extra files only in J's tree, outside the control
+                          directory (post-packet tree drift);
+      head_parents      — actual parents of J (default [R, S]).
+    """
+
+    def __init__(self, repo: Repo, *, packet_override=None, ledger=None, manifest=None,
+                 projection_extra: dict[str, bytes] | None = None,
+                 head_extra: dict[str, bytes] | None = None,
+                 head_parents: list[str] | None = None):
+        self.repo = repo
+        self.r = repo.make_commit({"README.md": b"perl-lsp base\n"}, [], "R: base\n")
+        self.s = repo.make_commit(dict(S_CONTENT), [], "S: prepared swarm\n")
+
+        ledger_bytes = json_bytes(ledger if ledger is not None else ledger_payload())
+        manifest_bytes = json_bytes(manifest if manifest is not None else manifest_payload())
+
+        projection = dict(PROJECTION_CONTENT)
+        if projection_extra:
+            projection.update(projection_extra)
+        projection_tree = repo.make_tree(projection)
+
+        self.core_join = repo.git(
+            "commit-tree", projection_tree, "-p", self.r, "-p", self.s,
+            input_bytes=JOIN_MESSAGE.encode(),
+        )
+        packet = {
+            "schema_version": "v0.18_publication_sync.v2",
+            "release": RELEASE,
+            "release_base_sha": self.r,
+            "prepared_swarm_sha": self.s,
+            "sync_join_sha": self.core_join,
+            "expected_join_parents": [self.r, self.s],
+            "reconciliation_digest": "sha256:" + hashlib.sha256(ledger_bytes).hexdigest(),
+            "publication_sync_manifest_digest": "sha256:"
+            + hashlib.sha256(manifest_bytes).hexdigest(),
+            "expected_projected_tree": projection_tree,
+            "published_channels": [],
+            "release_cut": False,
+        }
+        if packet_override:
+            packet.update(packet_override)
+
+        head_files = dict(projection)
+        if head_extra:
+            head_files.update(head_extra)
+        head_files[PACKET_PATH] = json_bytes(packet)
+        head_files[LEDGER_PATH] = ledger_bytes
+        head_files[MANIFEST_PATH] = manifest_bytes
+        actual_parents = head_parents if head_parents is not None else [self.r, self.s]
+        self.j = repo.make_commit(head_files, actual_parents, JOIN_MESSAGE)
+
+    def wrapper_merge(self) -> str:
+        """GitHub-style wrapper M: parents [master tip, J], tree == tree(J)."""
+        tree = self.repo.git("rev-parse", f"{self.j}^{{tree}}")
+        return self.repo.git(
+            "commit-tree", tree, "-p", self.r, "-p", self.j,
+            input_bytes=b"merge publication sync\n",
+        )
+
+
+def run_check(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(CHECK), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class PublicationSyncContractTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="pubsync-test-")
+        self.addCleanup(self._tmp.cleanup)
+        self.repo = Repo(Path(self._tmp.name) / "repo")
+        self.body_file = Path(self._tmp.name) / "body.md"
+
+    def write_body(self, body: str) -> str:
+        self.body_file.write_text(body, encoding="utf-8")
+        return str(self.body_file)
+
+    def run_pr(self, fixture: SyncFixture, body: str, *, base=None, head=None):
+        return run_check([
+            "pr",
+            "--repo", str(self.repo.path),
+            "--base-sha", base or fixture.r,
+            "--head-sha", head or fixture.j,
+            "--pr-body-file", self.write_body(body),
+        ])
+
+    def run_post_merge(self, merge_sha: str, *, master_at: str):
+        self.repo.git("update-ref", "refs/heads/master", master_at)
+        return run_check([
+            "post-merge",
+            "--repo", str(self.repo.path),
+            "--merge-sha", merge_sha,
+        ])
+
+    # --- positive controls ---------------------------------------------------
+
+    def test_ordinary_pr_not_applicable(self) -> None:
+        commit = self.repo.make_commit({"src/lib.rs": b"fn main() {}\n"}, [], "ordinary\n")
+        for body in (BODY_NO, BODY_ABSENT, BODY_TITLE_LIKE):
+            proc = run_check([
+                "pr", "--repo", str(self.repo.path),
+                "--base-sha", commit, "--head-sha", commit,
+                "--pr-body-file", self.write_body(body),
+            ])
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            self.assertIn("publication-sync: not_applicable", proc.stdout)
+
+    def test_not_applicable_is_deterministic(self) -> None:
+        commit = self.repo.make_commit({"src/lib.rs": b"fn main() {}\n"}, [], "ordinary\n")
+        outputs = []
+        for _ in range(2):
+            proc = run_check([
+                "pr", "--repo", str(self.repo.path),
+                "--base-sha", commit, "--head-sha", commit,
+                "--pr-body-file", self.write_body(BODY_NO),
+            ])
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            outputs.append(proc.stdout)
+        self.assertEqual(outputs[0], outputs[1])
+
+    def test_exact_synthetic_join_passes(self) -> None:
+        fixture = SyncFixture(self.repo)
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        for proof in range(1, 12):
+            self.assertIn(f"PASS proof {proof}:", proc.stdout)
+        self.assertIn("publication-sync: pass", proc.stdout)
+
+    def test_wrapper_merge_passes_post_merge(self) -> None:
+        fixture = SyncFixture(self.repo)
+        merge_m = fixture.wrapper_merge()
+        proc = self.run_post_merge(merge_m, master_at=merge_m)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("publication-sync post-merge: pass", proc.stdout)
+
+    # --- falsifiers ------------------------------------------------------------
+
+    def test_declared_sync_without_packet_fails(self) -> None:
+        commit = self.repo.make_commit({"src/lib.rs": b"x\n"}, [], "c\n")
+        proc = run_check([
+            "pr", "--repo", str(self.repo.path),
+            "--base-sha", commit, "--head-sha", commit,
+            "--pr-body-file", self.write_body(BODY_YES),
+        ])
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("without a committed packet", proc.stdout)
+
+    def test_packet_without_marker_fails(self) -> None:
+        fixture = SyncFixture(self.repo)
+        for body in (BODY_NO, BODY_ABSENT):
+            proc = self.run_pr(fixture, body)
+            self.assertEqual(proc.returncode, 1, body)
+            self.assertIn("may not arrive undeclared", proc.stdout)
+
+    def test_wrong_pr_base_fails(self) -> None:
+        fixture = SyncFixture(self.repo)
+        wrong_base = self.repo.make_commit({"other.txt": b"x\n"}, [], "wrong base\n")
+        proc = self.run_pr(fixture, BODY_YES, base=wrong_base)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 1", proc.stdout)
+
+    def test_head_not_declared_join_fails(self) -> None:
+        fixture = SyncFixture(self.repo, packet_override={"sync_join_sha": "0" * 40})
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 2", proc.stdout)
+
+    def test_head_tree_drift_after_packet_fails(self) -> None:
+        fixture = SyncFixture(self.repo, head_extra={"drift.txt": b"late change\n"})
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 2", proc.stdout)
+
+    def test_one_parent_join_fails(self) -> None:
+        fixture = SyncFixture(self.repo)
+        solo = self.repo.make_commit({"solo.txt": b"x\n"}, [], "solo parent\n")
+        one_parent = SyncFixture(self.repo, head_parents=[solo])
+        self.assertEqual(fixture.r, one_parent.r)  # deterministic fixture identity
+        proc = self.run_pr(one_parent, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 3", proc.stdout)
+
+    def test_reversed_parents_fail(self) -> None:
+        fixture = SyncFixture(self.repo)
+        reversed_head = SyncFixture(self.repo, head_parents=[fixture.s, fixture.r])
+        proc = self.run_pr(reversed_head, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 3", proc.stdout)
+
+    def test_correct_parents_wrong_tree_fails(self) -> None:
+        fixture = SyncFixture(
+            self.repo,
+            packet_override={"expected_projected_tree": "0" * 40},
+        )
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 7", proc.stdout)
+
+    def test_unreachable_s_fails_closed(self) -> None:
+        fixture = SyncFixture(self.repo)
+        # Shallow clone at depth 1: R and S are beyond the boundary, so
+        # ancestry/parent evidence is missing and must fail, never pass.
+        self.repo.git("update-ref", "refs/heads/master", fixture.j)
+        shallow = Path(self._tmp.name) / "shallow"
+        subprocess.run(
+            ["git", "clone", "-q", "--depth", "1", f"file://{self.repo.path}", str(shallow)],
+            check=True,
+            capture_output=True,
+        )
+        proc = run_check([
+            "pr", "--repo", str(shallow),
+            "--base-sha", fixture.r, "--head-sha", fixture.j,
+            "--pr-body-file", self.write_body(BODY_YES),
+        ])
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("Publication Sync Contract FAILED", proc.stdout)
+
+    def test_unlisted_path_diff_fails(self) -> None:
+        fixture = SyncFixture(
+            self.repo,
+            projection_extra={"unlisted/evil.txt": b"not in manifest\n"},
+        )
+        # The projection tree changed consistently with the packet; only the
+        # manifest fails to list the extra path.
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 8", proc.stdout)
+        self.assertIn("unlisted/evil.txt", proc.stdout)
+
+    def test_blocking_reconciliation_decision_fails(self) -> None:
+        fixture = SyncFixture(self.repo, ledger=ledger_payload(status="blocked"))
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 5", proc.stdout)
+        self.assertIn("blocked", proc.stdout)
+
+    def test_ledger_digest_mismatch_fails(self) -> None:
+        fixture = SyncFixture(
+            self.repo,
+            packet_override={"reconciliation_digest": "sha256:" + "0" * 64},
+        )
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("proof 5", proc.stdout)
+
+    def test_not_proven_invariant_fails(self) -> None:
+        fixture = SyncFixture(self.repo, manifest=manifest_payload(status="not_proven"))
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("not_proven", proc.stdout)
+
+    def test_missing_required_invariant_fails(self) -> None:
+        manifest = manifest_payload()
+        manifest["required_invariants"] = [
+            inv for inv in manifest["required_invariants"] if inv["id"] != "topology"
+        ]
+        fixture = SyncFixture(self.repo, manifest=manifest)
+        proc = self.run_pr(fixture, BODY_YES)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("topology", proc.stdout)
+
+    def test_squash_wrapper_fails_post_merge(self) -> None:
+        fixture = SyncFixture(self.repo)
+        # Simulated GitHub squash: same tree as J, single parent, J lost.
+        tree = self.repo.git("rev-parse", f"{fixture.j}^{{tree}}")
+        squash_m = self.repo.git(
+            "commit-tree", tree, "-p", fixture.r, input_bytes=b"squashed sync\n"
+        )
+        proc = self.run_post_merge(squash_m, master_at=squash_m)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("squash/rebase", proc.stdout)
+
+    def test_post_merge_master_mismatch_fails(self) -> None:
+        fixture = SyncFixture(self.repo)
+        merge_m = fixture.wrapper_merge()
+        other = self.repo.make_commit({"x.txt": b"x\n"}, [], "other tip\n")
+        proc = self.run_post_merge(merge_m, master_at=other)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("refs/heads/master", proc.stdout)
+
+    def test_publish_fields_fail_closed(self) -> None:
+        for override in (
+            {"published_channels": ["crates.io"]},
+            {"release_cut": True},
+        ):
+            fixture = SyncFixture(self.repo, packet_override=override)
+            proc = self.run_pr(fixture, BODY_YES)
+            self.assertEqual(proc.returncode, 1, override)
+            self.assertIn("no-publish contract", proc.stdout)
+
+    def test_packet_schema_ratchet(self) -> None:
+        for override in (
+            {"unexpected": "key"},
+            {"release_base_sha": "not-a-sha"},
+            {"schema_version": "v0.18_publication_sync.v1"},
+        ):
+            fixture = SyncFixture(self.repo, packet_override=override)
+            proc = self.run_pr(fixture, BODY_YES)
+            self.assertEqual(proc.returncode, 1, override)
+
+    def test_conflicting_marker_values_fail(self) -> None:
+        fixture = SyncFixture(self.repo)
+        body = BODY_YES + "\n- Publication-sync PR (yes/no): no\n"
+        proc = self.run_pr(fixture, body)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("conflicting", proc.stdout)
+
+    def test_crlf_body_still_enters_sync_mode(self) -> None:
+        # GitHub may deliver PR bodies with CRLF endings; the marker must not
+        # silently read as absent (which would false-red a valid sync PR).
+        fixture = SyncFixture(self.repo)
+        proc = self.run_pr(fixture, BODY_YES.replace("\n", "\r\n"))
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("publication-sync: pass", proc.stdout)
+
+
+class ValidatorUnitTest(unittest.TestCase):
+    """Pure-function guards that need no git fixture."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+        try:
+            import publication_sync_check as check
+        finally:
+            sys.path.remove(str(SCRIPTS_DIR))
+        cls.check = check
+
+    def test_packet_shape_rejects_missing_keys(self) -> None:
+        with self.assertRaises(self.check.ContractFailure):
+            self.check.validate_packet_shape({})
+
+    def test_marker_field_parsing(self) -> None:
+        self.assertIs(self.check.check_marker_field(BODY_ABSENT), None)
+        self.assertIs(self.check.check_marker_field(BODY_NO), False)
+        self.assertIs(self.check.check_marker_field(BODY_YES), True)
+        with self.assertRaises(self.check.ContractFailure):
+            self.check.check_marker_field(BODY_YES + BODY_NO)
+
+
+class RatchetTest(unittest.TestCase):
+    """Workflow permission/context ratchet and schema/template drift guards."""
+
+    def test_workflow_has_no_publication_authority(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("write-all", text)
+        self.assertNotIn(": write", text)
+        self.assertNotIn("secrets.", text)
+        self.assertIn("contents: read", text)
+        forbidden_commands = (
+            "git push", "gh release", "cargo publish", "npm publish",
+            "docker push", "gh api", "winget", "scoop", "brew bump",
+            "chocolatey", "ovsx", "vsce publish",
+        )
+        for token in forbidden_commands:
+            self.assertNotIn(token, text, f"workflow must not contain {token!r}")
+
+    def test_validator_has_no_publication_command(self) -> None:
+        text = CHECK.read_text(encoding="utf-8")
+        forbidden_commands = (
+            "git push", "gh release", "cargo publish", "npm publish",
+            "docker push", "gh api", "vsce publish",
+        )
+        for token in forbidden_commands:
+            self.assertNotIn(token, text, f"validator must not contain {token!r}")
+
+    def test_exact_check_context_names(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        # The required status context is the job name; both workflow and job
+        # are pinned to the exact contract name so the ruleset context cannot
+        # drift silently.
+        self.assertTrue(text.startswith("name: Publication Sync Contract\n"))
+        self.assertIn("\n    name: Publication Sync Contract\n", text)
+
+    def test_schema_file_matches_validator(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        sys.path.insert(0, str(SCRIPTS_DIR))
+        try:
+            import publication_sync_check as check
+        finally:
+            sys.path.remove(str(SCRIPTS_DIR))
+        self.assertEqual(set(schema["required"]), check.PACKET_KEYS)
+        self.assertEqual(set(schema["properties"]), check.PACKET_KEYS)
+        self.assertEqual(schema["properties"]["schema_version"]["const"], check.SCHEMA_VERSION)
+        self.assertEqual(schema["properties"]["release"]["const"], check.RELEASE)
+
+    def test_pr_template_marker_line_matches_validator_regex(self) -> None:
+        template = PR_TEMPLATE.read_text(encoding="utf-8")
+        sys.path.insert(0, str(SCRIPTS_DIR))
+        try:
+            import publication_sync_check as check
+        finally:
+            sys.path.remove(str(SCRIPTS_DIR))
+        matches = list(check.MARKER_FIELD.finditer(template))
+        self.assertEqual(len(matches), 1, "template must carry exactly one marker field line")
+        self.assertEqual(matches[0].group(1).lower(), "no", "template default must be 'no'")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Objective

Add the minimum complete `Publication Sync Contract` check so the audited 0.18.0-rc.1 join can land on master without losing ancestry or accepting an unreviewed tree — perl-lsp#10088, Refs EffortlessMetrics/perl-lsp-swarm#12231, Advances EffortlessMetrics/perl-lsp-swarm#7647.

## Summary

One deterministic, least-privilege, read-only check named exactly `Publication Sync Contract` with two modes: ordinary PR → deterministic `not_applicable` success; explicit publication-sync PR → fail closed unless the exact packet, ancestry, tree, and no-publish contract pass (proofs 1–11 of the controlling issue). Sync mode requires BOTH repository-owned markers — the committed packet at `.github/publication-sync/packet.yaml` and the dedicated PR-template field — a title substring is not authority. Includes a `workflow_dispatch` post-merge mode proving wrapper merge `M` preserved join `J` (squash/rebase landings fail).

## Lane

- [x] trust
- [ ] substrate
- [ ] reliability

## Publication Sync

- Publication-sync PR (yes/no): no

## Claim Boundary

Claims: the check exists, is deterministic and read-only, fails closed on every falsifier in swarm#12231, and its exact context is proven to land on PRs (rehearsal PR #10089). Does NOT claim: that the real R/S/J packet values exist yet (they materialize with the actual sync PR, downstream), that the sibling projection verifier exists (this contract consumes its recorded evidence and fails closed on anything but explicit `pass`), or any product behavior change.

## Non-goals

No release-row classification. No publication manifest generation. No actual complete-tree join. No product or release metadata changes. No tag or public channel mutation. The actual publication-sync PR and the 0.18.0-rc.1 denominator (swarm#12228) are downstream/sibling work.

## Promotion Discipline

- Surface: `.github/workflows/publication-sync-contract.yml` + `scripts/publication_sync_check.py`
- Fact class: repository-owned merge-time evidence (packet, git ancestry, tree identity, digests)
- Promotion rule: a declared sync PR is merge-eligible only when proofs 1–11 pass on the exact head
- Fallback rule: any missing/skipped/uncertain evidence fails closed; ordinary PRs deterministically `not_applicable`
- Blocker rule: marker mismatch, packet drift, ancestry/tree/digest mismatch, `blocked`/`not_proven` evidence, or any publication authority in the check
- Receipt: rehearsal PR #10089 check run; ruleset 8029855 live read-back (2026-08-25T05:14:50Z)

## Behavior

- [x] no behavior change
- [ ] preview only
- [ ] scoped pilot
- [ ] live behavior change

## Risk Surfaces

- [ ] edit-producing
- [ ] provider behavior
- [x] subprocess (read-only git inspection plumbing in the validator)
- [ ] path/module resolution
- [ ] public API
- [ ] parser/lexer core

## Changes

- `.github/workflows/publication-sync-contract.yml` — the check; `permissions: contents: read`, no secrets/credentials; validator executed from the trusted PR base (bootstrap fallback to head copy only for this introducing PR, with a ::notice); post-merge `workflow_dispatch` mode.
- `scripts/publication_sync_check.py` — stdlib-deterministic validator implementing proofs 1–11 and the post-merge verifier. Commit-identity design: the packet names the *core join* J0 (same parents/message/identity as J, tree = projection without the control dir); proof 2 re-derives J0 from J exactly. Packet bytes must be JSON-parseable (JSON is valid YAML 1.2) to stay deterministic on the Python standard library.
- `schemas/publication_sync.v2.schema.json` — greenfield `v0.18_publication_sync.v2` packet schema + reconciliation-ledger and projection-manifest defs.
- `scripts/tests/test-publication-sync-contract.py` — 31 tests: synthetic git-graph fixtures for all 12 falsifiers + 3 positive controls, permission/command/context ratchet, schema/template drift guards.
- `.github/PULL_REQUEST_TEMPLATE.md` — dedicated `Publication-sync PR (yes/no)` marker field (default `no`).
- `.ci/policies/required-checks.toml` — inventory entry for the live-required context.

## Test

`scripts/tests/test-publication-sync-contract.py` fails without the validator and passes with it. Falsifiers covered: sync mode without packet; packet without marker; wrong PR base; head ≠ declared J; one-parent and reversed-parent joins; correct parents with wrong tree; unreachable S (shallow clone); one unlisted path differing from S; blocking reconciliation decision; unmatched digest; required `NOT_PROVEN` represented as pass; title-driven sync-mode entry; simulated GitHub squash wrapper; post-merge master mismatch; publish fields set; packet schema violations; conflicting markers. Positive controls: ordinary PR deterministic `not_applicable`; exact synthetic [R,S] join passes proofs 1–11; wrapper M preserving J passes post-merge.

## Verification

- [x] Lane and risk surface are declared above.
- [x] Trust-lane PRs name promotion, fallback, blocker, and receipt boundaries.
- [x] I used a narrow orthogonal pass first (focused fixture tests + actionlint) before any broader gate.
- [x] This PR introduces no Rust changes; cargo fmt/clippy/test are not the covering proof (no Rust surface touched).

## Local Proof Commands

- `python3 scripts/tests/test-publication-sync-contract.py` — pass (31 tests)
- `actionlint .github/workflows/publication-sync-contract.yml` — pass (clean)
- `cargo xtask workflow-policy-lint --check-lane-whitelist --receipt ...` — pass (0 errors; one advisory LANE_WHITELIST_MISSING warning for the new workflow, same class as existing advisories)
- `git diff --check` — pass
- `python3 -c 'tomllib/json parse of required-checks.toml and schema'` — pass
- Rehearsal PR #10089: check run `Publication Sync Contract` → success, log prints `publication-sync: not_applicable` — pass

## Quality Gates

- new RIPR gaps: none (no Rust surface)
- total RIPR+ gaps: unchanged
- patch coverage: unchanged
- project coverage: unchanged
- receipt freshness: workflow-policy receipt generated locally during lint run
- exception status: none requested
- local verify command: `python3 scripts/tests/test-publication-sync-contract.py`
- receipt command: `cargo xtask workflow-policy-lint --check-lane-whitelist --receipt target/receipts/workflow-policy.json`

## RIPR / Coverage Effect

No Rust change; no new RIPR gaps; coverage unchanged.

## Cleanup Performed

No scratch files committed; fixture repos are per-test tempdirs with automatic cleanup.

## Retained State

N/A

## What I considered but didn't do

- Parsing the packet as general YAML: rejected (no stdlib YAML; non-deterministic dependency); packet must be JSON-parseable, which is valid YAML 1.2.
- A `policy/ci-lane-whitelist.toml` entry: the lane-whitelist gap is warning-level/advisory for every new workflow; left to the CI-economics lane that owns that inventory.
- Requiring exactly one merge method via rules: GitHub cannot scope merge method by PR type; per the issue, the expected-head post-merge transaction is the enforcement backstop (squash/rebase landings fail it).

## Remaining Work

- Live ruleset receipt is recorded on swarm#12231 (ruleset 8029855 requires context `Publication Sync Contract` on `~DEFAULT_BRANCH`, read back 2026-08-25T05:14:50Z).
- The actual publication-sync PR (real R/S/J packet) and the 0.18.0-rc.1 denominator (swarm#12228) land downstream; this PR's post-merge mode is the verifier for that wrapper merge.

## CI cost / verification note

- [x] I used the cheapest relevant proof first.
- [x] I did not request broad CI unless this PR's risk surface needs it.
- [x] New CI work states the failure mode it catches and its estimated LEM: `Publication Sync Contract` catches unreviewed-tree/ancestry-loss publication syncs; ~20s on GitHub-hosted ubuntu-24.04, no Rust build, no self-hosted runner.

## Agent

Swarm lane root for swarm#12231 (RC04), model: kimi-code.

---

Refs EffortlessMetrics/perl-lsp-swarm#12231
Advances EffortlessMetrics/perl-lsp-swarm#7647