### PR TITLE
docs(sync): mark embedded protocol as historical snapshot (#10092)

### DIFF
--- a/docs/swarm/sync-protocol.md
+++ b/docs/swarm/sync-protocol.md
@@ -1,5 +1,22 @@
 # perl-lsp Sync Protocol
 
+> [!IMPORTANT]
+> **Historical promoted snapshot — not current sync authority.**
+>
+> This file records the sync protocol that was present in the publication
+> repository before the current protected publication-sync contract landed.
+> Current operating authority lives in
+> [`EffortlessMetrics/perl-lsp-swarm/docs/swarm/sync-protocol.md`](https://github.com/EffortlessMetrics/perl-lsp-swarm/blob/main/docs/swarm/sync-protocol.md),
+> with the copy-safe release procedure in
+> [`docs/how-to/PUBLICATION_SYNC.md`](https://github.com/EffortlessMetrics/perl-lsp-swarm/blob/main/docs/how-to/PUBLICATION_SYNC.md).
+>
+> In particular, the **Hard Invariant** below (that `perl-lsp/master` may never
+> be ahead of swarm) and the hard-coded v0.17 exclusion examples are historical
+> transaction rules, not current policy. The current contract permits
+> release-lineage-only divergence and requires every release-specific
+> product/test difference and publication projection to be explicitly
+> reconciled and digest-bound before the protected join.
+
 `perl-lsp-swarm` is the active development source of truth. `perl-lsp` is the
 release, history, and canonical package-lineage repo.
 


### PR DESCRIPTION
## Objective

Prevent release operators from treating the stale embedded `docs/swarm/sync-protocol.md` as current publication-sync authority.

## Summary

Adds a prominent top-of-file warning that this document is a **historical promoted snapshot** and points current operators to the canonical protocol and copy-safe runbook in `EffortlessMetrics/perl-lsp-swarm`.

The historical body is preserved verbatim for audit/lineage value. In particular, its old absolute ahead/behind invariant and v0.17 hard-coded exclusions are explicitly marked non-authoritative.

## Publication Sync

- Publication-sync PR (yes/no): no

## Claim Boundary

This is release-governance documentation only. It does not alter product behavior, branch protection, the live Publication Sync Contract, release packet/schema, or any publication channel.

## Verification

- authority warning is the first substantive content after the title;
- links point to canonical swarm protocol/runbook;
- historical body remains intact below the warning;
- ordinary `Publication Sync Contract` should report deterministic `not_applicable`.

## Non-goals

No sync transaction, ruleset/workflow change, tag, release, or package/channel publication.

Closes #10092.
Refs EffortlessMetrics/perl-lsp-swarm#7970.