### PR TITLE
fix(sync): preserve git commit message bytes on Windows

### DIFF
--- a/scripts/publication_sync_check.py
+++ b/scripts/publication_sync_check.py
@@ -130,20 +130,21 @@ def fail(message: str) -> NoReturn:
     raise ContractFailure(message)
 
 
-def run_git(repo: Path, args: Sequence[str], *, input_text: Optional[str] = None,
+def run_git(repo: Path, args: Sequence[str], *, input_bytes: Optional[bytes] = None,
             env: Optional[Dict[str, str]] = None) -> str:
-    """Run a git command; instrument failure is not success."""
+    """Run a git command with byte-preserving stdin and UTF-8 output."""
     proc = subprocess.run(
         ["git", "-C", str(repo), *args],
         capture_output=True,
-        text=True,
-        input=input_text,
+        input=input_bytes,
         env=env,
         check=False,
     )
     if proc.returncode != 0:
-        fail(f"git {' '.join(args)} failed: {proc.stderr.strip() or proc.stdout.strip()}")
-    return proc.stdout
+        stderr = proc.stderr.decode("utf-8", errors="replace").strip()
+        stdout = proc.stdout.decode("utf-8", errors="replace").strip()
+        fail(f"git {' '.join(args)} failed: {stderr or stdout}")
+    return proc.stdout.decode("utf-8", errors="replace")
 
 
 def git_ok(repo: Path, args: Sequence[str]) -> bool:
@@ -325,7 +326,8 @@ def ls_tree(repo: Path, treeish: str) -> List[str]:
 
 def mktree(repo: Path, entries: List[str]) -> str:
     """Build a tree object from ls-tree-format lines (git sorts them)."""
-    return run_git(repo, ["mktree"], input_text="\n".join(entries) + ("\n" if entries else "")).strip()
+    tree_input = "\n".join(entries) + ("\n" if entries else "")
+    return run_git(repo, ["mktree"], input_bytes=tree_input.encode("utf-8")).strip()
 
 
 def projected_tree(repo: Path, commit: str) -> str:
@@ -387,7 +389,7 @@ def derive_core_join(repo: Path, commit: str, parents: Sequence[str]) -> str:
     args = ["commit-tree", tree]
     for parent in parents:
         args += ["-p", parent]
-    return run_git(repo, args, input_text=message, env=env).strip()
+    return run_git(repo, args, input_bytes=message.encode("utf-8"), env=env).strip()
 
 
 def check_pr(args: argparse.Namespace) -> int:

--- a/scripts/tests/test-publication-sync-contract.py
+++ b/scripts/tests/test-publication-sync-contract.py
@@ -585,6 +585,14 @@ class RatchetTest(unittest.TestCase):
         for token in forbidden_commands:
             self.assertNotIn(token, text, f"validator must not contain {token!r}")
 
+    def test_git_plumbing_preserves_commit_message_bytes(self) -> None:
+        text = CHECK.read_text(encoding="utf-8")
+        run_git = text[text.index("def run_git"):text.index("def git_ok")]
+        self.assertIn("input_bytes: Optional[bytes] = None", text)
+        self.assertIn("capture_output=True,\n        input=input_bytes", run_git)
+        self.assertIn("input_bytes=message.encode(\"utf-8\")", text)
+        self.assertNotIn("text=True", run_git)
+
     def test_exact_check_context_names(self) -> None:
         text = WORKFLOW.read_text(encoding="utf-8")
         # The required status context is the job name; both workflow and job


### PR DESCRIPTION
## Objective

Fix the Windows-only publication-sync validation failure where text-mode subprocess stdin can translate the re-derived commit message to CRLF before `git commit-tree` hashes it.

## Change

- make the shared Git plumbing helper accept byte stdin and decode captured output explicitly;
- pass `commit_metadata`'s message bytes to `commit-tree` without newline translation;
- use the same byte-preserving path for `git mktree`;
- add a contract ratchet that prevents the object-construction helper from reverting to text-mode I/O.

## Verification

- `python3 -m py_compile scripts/publication_sync_check.py`
- `python3 scripts/tests/test-publication-sync-contract.py` — 36 tests passed
- `git diff --check` — clean

This is a contained CI/validator fix. It does not add publication authority or change the sync contract.

Closes #10091.