### PR TITLE
security: enforce 14-day dependency admission

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 14
     open-pull-requests-limit: 10
     groups:
       # Group all serde-related crates together
@@ -98,6 +100,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 14
     open-pull-requests-limit: 5
     groups:
       # Group all actions/* updates together
@@ -137,6 +141,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 14
     open-pull-requests-limit: 5
     groups:
       # Group all vscode related packages

--- a/vscode-extension/.npmrc
+++ b/vscode-extension/.npmrc
@@ -1,0 +1,2 @@
+# Hold newly published package versions for 14 days before normal resolution.
+min-release-age=14


### PR DESCRIPTION
Applies the 14-day dependency-admission boundary across the repository's current package managers without changing Cargo MSRV/toolchain policy:

- Dependabot: 14-day cooldown for Cargo, GitHub Actions, and the VS Code extension npm dependencies
- npm 11.18: project-level `vscode-extension/.npmrc` with `min-release-age=14`, covering newly resolved direct and transitive npm packages
- existing locked Cargo verification and package-lock/npm CI behavior remain intact

Dependabot security updates bypass the updater cooldown. The npm resolver gate is separate: if a required security fix is younger than 14 days, use a package-scoped `min-release-age-exclude` or equivalent reviewed temporary exception for that update.

Cargo-native minimum-publish-age stays deferred until Cargo 1.100 is naturally within toolchain policy.